### PR TITLE
Fixed 1 issue of type: PYTHON_F401 throughout 1 file in repo.

### DIFF
--- a/about/about.py
+++ b/about/about.py
@@ -65,7 +65,6 @@ class Ui_aboutAutoSplitWidget(object):
         self.donatebuttonLabel.setText(_translate("aboutAutoSplitWidget", "<html><head/><body><p><a href=\"https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=BYRHQG69YRHBA&item_name=AutoSplit+development&currency_code=USD&source=url\"><img src=\":/resources/donatebutton.png\"/></p></body></html>", None))
         self.iconLabel.setText(_translate("aboutAutoSplitWidget", "<html><head/><body><p><img src=\":/resources/icon.ico\"/></p></body></html>", None))
 
-import resources_rc
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        