### PR TITLE
Fix start issue after finishing splits 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable-next-line MD033 -->
 # <img src="res/icon.ico" alt="LiveSplit" height="42" width="42" align="top"/> AutoSplit [![CodeQL](/../../actions/workflows/codeql-analysis.yml/badge.svg)](/../../actions/workflows/codeql-analysis.yml) [![Lint and build](/../../actions/workflows/lint-and-build.yml/badge.svg)](/../../actions/workflows/lint-and-build.yml)
 
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=Avasam_Auto-Split&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=Avasam_Auto-Split)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Avasam_Auto-Split&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=Avasam_Auto-Split)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Avasam_Auto-Split&metric=security_rating)](https://sonarcloud.io/dashboard?id=Avasam_Auto-Split)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=Avasam_Auto-Split&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=Avasam_Auto-Split)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Avasam_Auto-Split&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Avasam_Auto-Split)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=Avasam_AutoSplit&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=Avasam_AutoSplit)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Avasam_AutoSplit&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=Avasam_AutoSplit)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Avasam_AutoSplit&metric=security_rating)](https://sonarcloud.io/dashboard?id=Avasam_AutoSplit)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=Avasam_AutoSplit&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=Avasam_AutoSplit)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Avasam_AutoSplit&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Avasam_AutoSplit)
 [![SemVer](https://badgen.net/badge/_/SemVer%20compliant/grey?label)](https://semver.org/)
 
 Easy to use image comparison based auto splitter for speedrunning on console or PC.

--- a/scripts/compile_resources.ps1
+++ b/scripts/compile_resources.ps1
@@ -17,7 +17,7 @@ If (-not $GITHUB_REPOSITORY) {
   $GITHUB_REPOSITORY = $repo_url.substring(19, $repo_url.length - 19) -replace '\.git', ''
 }
 If (-not $GITHUB_REPOSITORY) {
-  $GITHUB_REPOSITORY = 'Toufool/Auto-Split'
+  $GITHUB_REPOSITORY = 'Toufool/AutoSplit'
 }
 
 New-Item $build_vars_path -ItemType File -Force | Out-Null

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -513,18 +513,12 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
             error_messages.split_hotkey()
             return
 
+        # Set start time before parsing the images as it's a heavy operation that will cause delays
+        self.run_start_time = time()
+
         if not (validate_before_parsing(self) and parse_and_validate_images(self)):
             self.gui_changes_on_reset(True)
             return
-
-        # Initialize a few attributes
-        self.run_start_time = time()
-        self.split_image_number = 0
-        self.waiting_for_split_delay = False
-        self.split_below_threshold = False
-        split_time = 0
-        number_of_split_images = len(self.split_images_and_loop_number)
-        dummy_splits_array = [image_loop[0].check_flag(DUMMY_FLAG) for image_loop in self.split_images_and_loop_number]
 
         # Construct a list of images + loop count tuples.
         self.split_images_and_loop_number = [
@@ -553,6 +547,14 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
         # Start pause time
         if self.start_image:
             self.__pause_loop(self.start_image.get_pause_time(self), "None (Paused).")
+
+        # Initialize a few attributes
+        self.split_image_number = 0
+        self.waiting_for_split_delay = False
+        self.split_below_threshold = False
+        split_time = 0
+        number_of_split_images = len(self.split_images_and_loop_number)
+        dummy_splits_array = [image_loop[0].check_flag(DUMMY_FLAG) for image_loop in self.split_images_and_loop_number]
 
         # First loop: stays in this loop until all of the split images have been split
         while self.split_image_number < number_of_split_images:
@@ -618,6 +620,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
                 return
 
         # loop breaks to here when the last image splits
+        self.is_running = False
         self.gui_changes_on_reset(True)
 
     def __similarity_threshold_loop(self, number_of_split_images: int, dummy_splits_array: list[bool]):

--- a/src/capture_method/__init__.py
+++ b/src/capture_method/__init__.py
@@ -217,7 +217,7 @@ async def get_all_video_capture_devices() -> list[CameraInfo]:
     async def get_camera_info(index: int, device_name: str):
         backend = ""
         # Probing freezes some devices (like GV-USB2 and AverMedia) if already in use
-        # https://github.com/Toufool/Auto-Split/issues/169
+        # #169
         # FIXME: Maybe offer the option to the user to obtain more info about their devies?
         #        Off by default. With a tooltip to explain the risk.
         # video_capture = cv2.VideoCapture(index)


### PR DESCRIPTION
- `self.is_running = False` at the end of `__auto_splitter`
- Revert moving initialization of some values
- Move `self.run_start_time = time()` before parsing images

Closes #195

When I cleaned up the way the "started/stopped" state was tracked in https://github.com/Toufool/Auto-Split/commit/aa975fa999dfef7e67d1da37c03ba29334e0d6e9
I forgot to specify that it should stop running after the last split

So if you completed all your splits, it would go back to start image detection, but whenever it tried to "start" it would abort because it thought it was already running (kinda like if you send the "start" even from livesplit but autosplit was already started)