### PR TITLE
Linting and typing fixes

### DIFF
--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -8,6 +8,7 @@ import signal
 import sys
 from time import time
 from types import FunctionType
+from typing import NoReturn
 
 import certifi
 import cv2
@@ -694,6 +695,8 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
 
             QTest.qWait(wait_delta_ms)
 
+        return False
+
     def __pause_loop(self, stop_time: float, message: str):
         """
         Wait for a certain time and show the timer to the user.
@@ -870,7 +873,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):  # pylint: disable=too-many-
         Exit safely when closing the window
         """
 
-        def exit_program():
+        def exit_program() -> NoReturn:
             if self.update_auto_control:
                 self.update_auto_control.terminate()
             self.capture_method.close(self)

--- a/src/error_messages.py
+++ b/src/error_messages.py
@@ -6,7 +6,7 @@ import signal
 import sys
 import traceback
 from types import TracebackType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 from PyQt6 import QtCore, QtWidgets
 
@@ -185,7 +185,7 @@ def make_excepthook(autosplit: AutoSplit):
     return excepthook
 
 
-def handle_top_level_exceptions(exception: Exception):
+def handle_top_level_exceptions(exception: Exception) -> NoReturn:
     message = f"AutoSplit encountered an unrecoverable exception and will likely now close. {CREATE_NEW_ISSUE_MESSAGE}"
     # Print error to console if not running in executable
     if FROZEN:

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -12,7 +12,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtTest import QTest
 from win32 import win32gui
 from win32con import SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN
-from winsdk._winrt import initialize_with_window
+from winsdk._winrt import initialize_with_window  # pylint: disable=no-name-in-module
 from winsdk.windows.foundation import AsyncStatus, IAsyncOperation
 from winsdk.windows.graphics.capture import GraphicsCaptureItem, GraphicsCapturePicker
 


### PR DESCRIPTION
No functional changes. Just linter updates with explicit returns.

Pylint is sometimes inconsistent on the CI compared to local runs. And is thankfully going away with #207  (even if Ruff hasn't yet re-implemented all of pylint's very useful rules)