### PR TITLE
Backport a handful of improvements from the Linux branch

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       fail-fast: false
-      # Ruff is version and platform sensible
+      # Ruff is version sensible
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       # Only the Python version we plan on shipping matters.
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
     steps:
       - name: Checkout ${{ github.repository }}/${{ github.ref }}
         uses: actions/checkout@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,4 +96,18 @@
   "terminal.integrated.defaultProfile.windows": "PowerShell",
   "xml.codeLens.enabled": true,
   "xml.format.spaceBeforeEmptyCloseTag": false,
+  "xml.format.preserveSpace": [
+    // Default
+    "xsl:text",
+    "xsl:comment",
+    "xsl:processing-instruction",
+    "literallayout",
+    "programlisting",
+    "screen",
+    "synopsis",
+    "pre",
+    "xd:pre",
+    // Custom
+    "string"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,8 +59,7 @@
   },
   "[python]": {
     // Ruff is not yet a formatter: https://github.com/charliermarsh/ruff/issues/1904
-    // Cannot use autotpep8 until https://github.com/microsoft/vscode-autopep8/issues/32 is fixed
-    "editor.defaultFormatter": "ms-python.python",
+    "editor.defaultFormatter": "ms-python.autopep8",
     "editor.tabSize": 4,
     "editor.rulers": [
       72, // PEP8-17 docstrings
@@ -73,7 +72,6 @@
   // Important to follow the config in pyrightconfig.json
   "python.analysis.useLibraryCodeForTypes": false,
   "python.analysis.diagnosticMode": "workspace",
-  "python.formatting.provider": "autopep8",
   "python.linting.enabled": true,
   "ruff.importStrategy": "fromEnvironment",
   // Use the Ruff extension instead
@@ -84,6 +82,8 @@
   "python.linting.pycodestyleEnabled": false,
   "python.linting.pylamaEnabled": false,
   "python.linting.pylintEnabled": false,
+  // Use the autopep8 extension instead
+  "python.formatting.provider": "none",
   // Use Pyright/Pylance instead
   "python.linting.mypyEnabled": false,
   "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Refer to the [build instructions](build%20instructions.md) if you'd like to buil
   - Perceptual Hash: An explanation on pHash comparison can be found [here](http://www.hackerfactor.com/blog/index.php?/archives/432-Looks-Like-It.html). It is highly recommended to NOT use pHash if you use masked images, or it'll be very inaccurate.
 
 #### Capture Method
+<!-- Keep all descriptions in sync with in-code descriptions in src/capture_method/*CaptureMethod.py-->
 
 - **Windows Graphics Capture** (fast, most compatible, capped at 60fps)  
     Only available in Windows 10.0.17134 and up.  
@@ -94,7 +95,8 @@ Refer to the [build instructions](build%20instructions.md) if you'd like to buil
 
 #### Capture Device
 
-Select the Video Capture Device that you wanna use if selecting the `Video Capture Device` Capture Method.  <!-- Will show `[occupied]` if a device is detected but can't be started. (currently disabled because poking at devices to turn turn them off freezes some like the GV-USB2)-->
+Select the Video Capture Device that you wanna use if selecting the `Video Capture Device` Capture Method.
+<!-- Will show `[occupied]` if a device is detected but can't be started. (feature currently disabled because poking at devices to turn turn them off freezes some like the GV-USB2)-->
 
 #### Show Live Similarity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ max-branches = 15
 # https://github.com/hhatto/autopep8#more-advanced-usage
 [tool.autopep8]
 max_line_length = 120
-recursive = true
 aggressive = 3
 ignore = [
   "E124", # Closing bracket may not match multi-line method invocation style (enforced by add-trailing-comma)

--- a/res/about.ui
+++ b/res/about.ui
@@ -32,9 +32,7 @@
   </property>
   <property name="windowIcon">
    <iconset resource="resources.qrc">
-    <normaloff>:/resources/icon.ico</normaloff>
-    :/resources/icon.ico
-   </iconset>
+    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
   </property>
   <widget class="QPushButton" name="ok_button">
    <property name="geometry">
@@ -115,7 +113,7 @@ Thank you!</string>
   <widget class="QLabel" name="icon_label">
    <property name="geometry">
     <rect>
-     <x>181</x>
+     <x>190</x>
      <y>17</y>
      <width>64</width>
      <height>64</height>

--- a/res/design.ui
+++ b/res/design.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>777</width>
-    <height>424</height>
+    <width>786</width>
+    <height>426</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>777</width>
-    <height>424</height>
+    <width>786</width>
+    <height>426</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>777</width>
-    <height>424</height>
+    <width>786</width>
+    <height>426</height>
    </size>
   </property>
   <property name="font">
@@ -39,8 +39,8 @@
     <property name="geometry">
      <rect>
       <x>11</x>
-      <y>143</y>
-      <width>44</width>
+      <y>140</y>
+      <width>49</width>
       <height>20</height>
      </rect>
     </property>
@@ -56,7 +56,7 @@
      <rect>
       <x>10</x>
       <y>67</y>
-      <width>101</width>
+      <width>107</width>
       <height>23</height>
      </rect>
     </property>
@@ -70,7 +70,7 @@
    <widget class="QPushButton" name="start_auto_splitter_button">
     <property name="geometry">
      <rect>
-      <x>650</x>
+      <x>657</x>
       <y>369</y>
       <width>121</width>
       <height>27</height>
@@ -89,7 +89,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>650</x>
+      <x>657</x>
       <y>339</y>
       <width>121</width>
       <height>27</height>
@@ -108,7 +108,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>650</x>
+      <x>657</x>
       <y>310</y>
       <width>59</width>
       <height>27</height>
@@ -127,7 +127,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>712</x>
+      <x>719</x>
       <y>310</y>
       <width>59</width>
       <height>27</height>
@@ -144,7 +144,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>253</y>
+      <y>270</y>
       <width>53</width>
       <height>23</height>
      </rect>
@@ -163,8 +163,8 @@
     <property name="geometry">
      <rect>
       <x>92</x>
-      <y>254</y>
-      <width>20</width>
+      <y>272</y>
+      <width>21</width>
       <height>20</height>
      </rect>
     </property>
@@ -175,7 +175,7 @@
    <widget class="QLabel" name="live_image">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>127</x>
       <y>67</y>
       <width>320</width>
       <height>240</height>
@@ -203,7 +203,7 @@
    <widget class="QLabel" name="current_split_image">
     <property name="geometry">
      <rect>
-      <x>449</x>
+      <x>456</x>
       <y>67</y>
       <width>320</width>
       <height>240</height>
@@ -222,7 +222,7 @@
    <widget class="QLabel" name="current_image_label">
     <property name="geometry">
      <rect>
-      <x>449</x>
+      <x>456</x>
       <y>31</y>
       <width>318</width>
       <height>20</height>
@@ -239,8 +239,8 @@
     <property name="geometry">
      <rect>
       <x>11</x>
-      <y>183</y>
-      <width>44</width>
+      <y>190</y>
+      <width>49</width>
       <height>20</height>
      </rect>
     </property>
@@ -255,8 +255,8 @@
     <property name="geometry">
      <rect>
       <x>66</x>
-      <y>183</y>
-      <width>44</width>
+      <y>190</y>
+      <width>49</width>
       <height>20</height>
      </rect>
     </property>
@@ -271,7 +271,7 @@
     <property name="geometry">
      <rect>
       <x>65</x>
-      <y>254</y>
+      <y>272</y>
       <width>26</width>
       <height>20</height>
      </rect>
@@ -284,8 +284,8 @@
     <property name="geometry">
      <rect>
       <x>11</x>
-      <y>200</y>
-      <width>44</width>
+      <y>210</y>
+      <width>51</width>
       <height>24</height>
      </rect>
     </property>
@@ -306,8 +306,8 @@
     <property name="geometry">
      <rect>
       <x>66</x>
-      <y>200</y>
-      <width>44</width>
+      <y>210</y>
+      <width>51</width>
       <height>24</height>
      </rect>
     </property>
@@ -327,7 +327,7 @@
    <widget class="QLabel" name="capture_region_label">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>127</x>
       <y>31</y>
       <width>318</width>
       <height>20</height>
@@ -343,7 +343,7 @@
    <widget class="QLabel" name="current_image_file_label">
     <property name="geometry">
      <rect>
-      <x>477</x>
+      <x>484</x>
       <y>49</y>
       <width>264</width>
       <height>20</height>
@@ -360,8 +360,8 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>227</y>
-      <width>101</width>
+      <y>240</y>
+      <width>107</width>
       <height>23</height>
      </rect>
     </property>
@@ -377,7 +377,7 @@
      <rect>
       <x>11</x>
       <y>160</y>
-      <width>44</width>
+      <width>51</width>
       <height>24</height>
      </rect>
     </property>
@@ -405,7 +405,7 @@
      <rect>
       <x>66</x>
       <y>160</y>
-      <width>44</width>
+      <width>51</width>
       <height>24</height>
      </rect>
     </property>
@@ -426,8 +426,8 @@
     <property name="geometry">
      <rect>
       <x>66</x>
-      <y>143</y>
-      <width>44</width>
+      <y>140</y>
+      <width>49</width>
       <height>20</height>
      </rect>
     </property>
@@ -443,7 +443,7 @@
      <rect>
       <x>10</x>
       <y>119</y>
-      <width>101</width>
+      <width>107</width>
       <height>23</height>
      </rect>
     </property>
@@ -462,7 +462,7 @@
      <rect>
       <x>10</x>
       <y>93</y>
-      <width>101</width>
+      <width>107</width>
       <height>23</height>
      </rect>
     </property>
@@ -478,7 +478,7 @@
      <rect>
       <x>696</x>
       <y>5</y>
-      <width>75</width>
+      <width>81</width>
       <height>24</height>
      </rect>
     </property>
@@ -494,7 +494,7 @@
      <rect>
       <x>10</x>
       <y>9</y>
-      <width>98</width>
+      <width>111</width>
       <height>16</height>
      </rect>
     </property>
@@ -505,9 +505,9 @@
    <widget class="QLineEdit" name="split_image_folder_input">
     <property name="geometry">
      <rect>
-      <x>119</x>
+      <x>127</x>
       <y>6</y>
-      <width>574</width>
+      <width>561</width>
       <height>22</height>
      </rect>
     </property>
@@ -518,7 +518,7 @@
    <widget class="QLabel" name="capture_region_window_label">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>127</x>
       <y>49</y>
       <width>318</width>
       <height>20</height>
@@ -534,9 +534,9 @@
    <widget class="QLabel" name="image_loop_label">
     <property name="geometry">
      <rect>
-      <x>451</x>
+      <x>458</x>
       <y>313</y>
-      <width>67</width>
+      <width>81</width>
       <height>20</height>
      </rect>
     </property>
@@ -547,7 +547,7 @@
    <widget class="QGroupBox" name="similarity_viewer_groupbox">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>127</x>
       <y>312</y>
       <width>321</width>
       <height>84</height>
@@ -798,9 +798,9 @@
    <widget class="QPushButton" name="reload_start_image_button">
     <property name="geometry">
      <rect>
-      <x>450</x>
+      <x>457</x>
       <y>369</y>
-      <width>121</width>
+      <width>131</width>
       <height>27</height>
      </rect>
     </property>
@@ -814,10 +814,10 @@
    <widget class="QLabel" name="start_image_status_label">
     <property name="geometry">
      <rect>
-      <x>449</x>
+      <x>458</x>
       <y>344</y>
-      <width>101</width>
-      <height>16</height>
+      <width>121</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
@@ -827,10 +827,10 @@
    <widget class="QLabel" name="start_image_status_value_label">
     <property name="geometry">
      <rect>
-      <x>560</x>
+      <x>577</x>
       <y>344</y>
-      <width>98</width>
-      <height>16</height>
+      <width>81</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
@@ -840,9 +840,9 @@
    <widget class="QLabel" name="image_loop_value_label">
     <property name="geometry">
      <rect>
-      <x>520</x>
+      <x>537</x>
       <y>313</y>
-      <width>131</width>
+      <width>121</width>
       <height>20</height>
      </rect>
     </property>
@@ -856,7 +856,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>448</x>
+      <x>455</x>
       <y>49</y>
       <width>27</width>
       <height>18</height>
@@ -878,7 +878,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>743</x>
+      <x>750</x>
       <y>49</y>
       <width>27</width>
       <height>18</height>
@@ -936,7 +936,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>777</width>
+     <width>786</width>
      <height>22</height>
     </rect>
    </property>

--- a/res/settings.ui
+++ b/res/settings.ui
@@ -32,9 +32,7 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>:/resources/icon.ico</normaloff>
-    :/resources/icon.ico
-   </iconset>
+    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
   </property>
   <widget class="QGroupBox" name="capture_settings_groupbox">
    <property name="geometry">
@@ -202,8 +200,8 @@ Histograms:
 An explanation on Histograms comparison can be found here
 https://mpatacchiola.github.io/blog/2016/11/12/the-simplest-classifier-histogram-intersection.html
 This is a great method to use if you are using several masked images.
-> This algorithm is particular reliable when the colour is a strong predictor of the object identity.
-> The histogram intersection [...] is robust to occluding objects in the foreground.
+&gt; This algorithm is particular reliable when the colour is a strong predictor of the object identity.
+&gt; The histogram intersection [...] is robust to occluding objects in the foreground.
 
 Perceptual Hash:
 An explanation on pHash comparison can be found here
@@ -737,11 +735,11 @@ reset image</string>
   </widget>
  </widget>
  <tabstops>
-  <tabstop>split_input</tabstop>
-  <tabstop>reset_input</tabstop>
-  <tabstop>undo_split_input</tabstop>
-  <tabstop>skip_split_input</tabstop>
-  <tabstop>pause_input</tabstop>
+  <tabstop>set_split_hotkey_button</tabstop>
+  <tabstop>set_reset_hotkey_button</tabstop>
+  <tabstop>set_undo_split_hotkey_button</tabstop>
+  <tabstop>set_skip_split_hotkey_button</tabstop>
+  <tabstop>set_pause_hotkey_button</tabstop>
   <tabstop>fps_limit_spinbox</tabstop>
   <tabstop>live_capture_region_checkbox</tabstop>
   <tabstop>capture_method_combobox</tabstop>

--- a/res/settings.ui
+++ b/res/settings.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>291</width>
-    <height>661</height>
+    <width>290</width>
+    <height>664</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>291</width>
-    <height>661</height>
+    <width>290</width>
+    <height>664</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>291</width>
-    <height>661</height>
+    <width>290</width>
+    <height>664</height>
    </size>
   </property>
   <property name="font">
@@ -39,7 +39,7 @@
     <rect>
      <x>10</x>
      <y>200</y>
-     <width>271</width>
+     <width>270</width>
      <height>181</height>
     </rect>
    </property>
@@ -49,10 +49,10 @@
    <widget class="QSpinBox" name="fps_limit_spinbox">
     <property name="geometry">
      <rect>
-      <x>138</x>
-      <y>25</y>
+      <x>150</x>
+      <y>24</y>
       <width>51</width>
-      <height>22</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="correctionMode">
@@ -73,7 +73,7 @@
      <rect>
       <x>6</x>
       <y>27</y>
-      <width>121</width>
+      <width>141</width>
       <height>16</height>
      </rect>
     </property>
@@ -85,14 +85,11 @@
     </property>
    </widget>
    <widget class="QCheckBox" name="live_capture_region_checkbox">
-    <property name="enabled">
-     <bool>true</bool>
-    </property>
     <property name="geometry">
      <rect>
       <x>6</x>
       <y>49</y>
-      <width>129</width>
+      <width>141</width>
       <height>20</height>
      </rect>
     </property>
@@ -164,8 +161,8 @@
     <rect>
      <x>10</x>
      <y>390</y>
-     <width>271</width>
-     <height>261</height>
+     <width>270</width>
+     <height>266</height>
     </rect>
    </property>
    <property name="title">
@@ -183,9 +180,9 @@
    <widget class="QComboBox" name="default_comparison_method">
     <property name="geometry">
      <rect>
-      <x>167</x>
+      <x>170</x>
       <y>25</y>
-      <width>88</width>
+      <width>91</width>
       <height>22</height>
      </rect>
     </property>
@@ -229,7 +226,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>28</y>
-      <width>161</width>
+      <width>171</width>
       <height>16</height>
      </rect>
     </property>
@@ -242,7 +239,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>118</y>
-      <width>161</width>
+      <width>171</width>
       <height>16</height>
      </rect>
     </property>
@@ -253,10 +250,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QDoubleSpinBox" name="default_pause_time_spinbox">
     <property name="geometry">
      <rect>
-      <x>167</x>
+      <x>170</x>
       <y>115</y>
-      <width>87</width>
-      <height>22</height>
+      <width>91</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="toolTip">
@@ -283,7 +280,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>58</y>
-      <width>151</width>
+      <width>171</width>
       <height>16</height>
      </rect>
     </property>
@@ -294,10 +291,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QDoubleSpinBox" name="default_similarity_threshold_spinbox">
     <property name="geometry">
      <rect>
-      <x>167</x>
+      <x>170</x>
       <y>55</y>
-      <width>52</width>
-      <height>22</height>
+      <width>51</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="toolTip">
@@ -317,14 +314,11 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     </property>
    </widget>
    <widget class="QCheckBox" name="loop_splits_checkbox">
-    <property name="enabled">
-     <bool>true</bool>
-    </property>
     <property name="geometry">
      <rect>
       <x>6</x>
       <y>143</y>
-      <width>235</width>
+      <width>261</width>
       <height>20</height>
      </rect>
     </property>
@@ -342,9 +336,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>6</x>
-      <y>190</y>
+      <y>193</y>
       <width>261</width>
-      <height>61</height>
+      <height>71</height>
      </rect>
     </property>
     <property name="font">
@@ -365,7 +359,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>88</y>
-      <width>161</width>
+      <width>171</width>
       <height>16</height>
      </rect>
     </property>
@@ -376,10 +370,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QSpinBox" name="default_delay_time_spinbox">
     <property name="geometry">
      <rect>
-      <x>167</x>
+      <x>170</x>
       <y>85</y>
-      <width>87</width>
-      <height>22</height>
+      <width>91</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="toolTip">
@@ -396,7 +390,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>140</x>
-      <y>210</y>
+      <y>218</y>
       <width>71</width>
       <height>31</height>
      </rect>
@@ -425,7 +419,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>168</y>
-      <width>151</width>
+      <width>171</width>
       <height>20</height>
      </rect>
     </property>
@@ -442,7 +436,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>271</width>
+     <width>270</width>
      <height>191</height>
     </rect>
    </property>
@@ -464,7 +458,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
       <x>180</x>
       <y>130</y>
       <width>81</width>
-      <height>21</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -475,15 +469,12 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     </property>
    </widget>
    <widget class="QLineEdit" name="split_input">
-    <property name="enabled">
-     <bool>true</bool>
-    </property>
     <property name="geometry">
      <rect>
-      <x>76</x>
+      <x>80</x>
       <y>30</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -496,10 +487,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QLineEdit" name="undo_split_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
+      <x>80</x>
       <y>80</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -525,10 +516,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QLineEdit" name="reset_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
+      <x>80</x>
       <y>55</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -544,7 +535,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
       <x>180</x>
       <y>80</y>
       <width>81</width>
-      <height>21</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -589,7 +580,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
       <x>180</x>
       <y>30</y>
       <width>81</width>
-      <height>21</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -615,10 +606,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QLineEdit" name="pause_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
+      <x>80</x>
       <y>130</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -647,7 +638,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
       <x>180</x>
       <y>105</y>
       <width>81</width>
-      <height>21</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -673,10 +664,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QLineEdit" name="skip_split_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
+      <x>80</x>
       <y>105</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -692,7 +683,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
       <x>180</x>
       <y>155</y>
       <width>81</width>
-      <height>21</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -719,10 +710,10 @@ reset image</string>
    <widget class="QLineEdit" name="toggle_auto_reset_image_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
+      <x>80</x>
       <y>155</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">

--- a/res/settings.ui
+++ b/res/settings.ui
@@ -397,6 +397,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     </property>
     <property name="font">
      <font>
+      <family>Segoe UI</family>
       <pointsize>8</pointsize>
       <bold>true</bold>
      </font>

--- a/res/update_checker.ui
+++ b/res/update_checker.ui
@@ -9,20 +9,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>313</width>
-    <height>133</height>
+    <width>318</width>
+    <height>132</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>313</width>
-    <height>133</height>
+    <width>318</width>
+    <height>132</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>313</width>
-    <height>133</height>
+    <width>318</width>
+    <height>132</height>
    </size>
   </property>
   <property name="font">
@@ -43,9 +43,9 @@
   <widget class="QLabel" name="update_status_label">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>10</y>
-     <width>218</width>
+     <width>251</width>
      <height>16</height>
     </rect>
    </property>
@@ -62,9 +62,9 @@
   <widget class="QLabel" name="current_version_label">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>30</y>
-     <width>91</width>
+     <width>101</width>
      <height>16</height>
     </rect>
    </property>
@@ -75,9 +75,9 @@
   <widget class="QLabel" name="latest_version_label">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>50</y>
-     <width>81</width>
+     <width>101</width>
      <height>16</height>
     </rect>
    </property>
@@ -88,9 +88,9 @@
   <widget class="QLabel" name="go_to_download_label">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>80</y>
-     <width>119</width>
+     <width>141</width>
      <height>16</height>
     </rect>
    </property>
@@ -101,9 +101,9 @@
   <widget class="QPushButton" name="left_button">
    <property name="geometry">
     <rect>
-     <x>150</x>
+     <x>160</x>
      <y>100</y>
-     <width>75</width>
+     <width>71</width>
      <height>24</height>
     </rect>
    </property>
@@ -117,9 +117,9 @@
   <widget class="QPushButton" name="right_button">
    <property name="geometry">
     <rect>
-     <x>230</x>
+     <x>240</x>
      <y>100</y>
-     <width>75</width>
+     <width>71</width>
      <height>24</height>
     </rect>
    </property>
@@ -130,9 +130,9 @@
   <widget class="QLabel" name="current_version_number_label">
    <property name="geometry">
     <rect>
-     <x>120</x>
+     <x>110</x>
      <y>30</y>
-     <width>181</width>
+     <width>191</width>
      <height>16</height>
     </rect>
    </property>
@@ -143,9 +143,9 @@
   <widget class="QLabel" name="latest_version_number_label">
    <property name="geometry">
     <rect>
-     <x>120</x>
+     <x>110</x>
      <y>50</y>
-     <width>181</width>
+     <width>191</width>
      <height>16</height>
     </rect>
    </property>
@@ -156,9 +156,9 @@
   <widget class="QCheckBox" name="do_not_ask_again_checkbox">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>102</y>
-     <width>131</width>
+     <width>151</width>
      <height>20</height>
     </rect>
    </property>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,10 +1,11 @@
 & "$PSScriptRoot/compile_resources.ps1"
 
 $arguments = @(
+  "$PSScriptRoot/../src/AutoSplit.py",
   '--onefile',
   '--windowed',
   '--additional-hooks-dir=Pyinstaller/hooks',
   '--icon=res/icon.ico',
   '--splash=res/splash.png')
 
-pyinstaller $arguments "$PSScriptRoot/../src/AutoSplit.py"
+Start-Process -Wait -NoNewWindow pyinstaller -ArgumentList $arguments

--- a/scripts/designer.ps1
+++ b/scripts/designer.ps1
@@ -1,4 +1,10 @@
-$qt6_applications_path = python -c 'import qt6_applications; print(qt6_applications.__path__[0])'
+$qt6_applications_import = 'import qt6_applications; print(qt6_applications.__path__[0])'
+$qt6_applications_path = python -c $qt6_applications_import
+if ($null -eq $qt6_applications_path) {
+  Write-Host 'Designer not found, installing qt6_applications'
+  python -m pip install qt6_applications
+}
+$qt6_applications_path = python -c $qt6_applications_import
 & "$qt6_applications_path/Qt/bin/designer" `
   "$PSScriptRoot/../res/design.ui" `
   "$PSScriptRoot/../res/about.ui" `

--- a/scripts/designer.ps1
+++ b/scripts/designer.ps1
@@ -1,4 +1,4 @@
-$qt6_applications_path = python3 -c 'import qt6_applications; print(qt6_applications.__path__[0])'
+$qt6_applications_path = python -c 'import qt6_applications; print(qt6_applications.__path__[0])'
 & "$qt6_applications_path/Qt/bin/designer" `
   "$PSScriptRoot/../res/design.ui" `
   "$PSScriptRoot/../res/about.ui" `

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,14 +1,7 @@
-# Alias python3 to python on Windows
-If ($IsWindows) {
-  $python = (Get-Command python).Source
-  $python3 = "$((Get-Item $python).Directory.FullName)/python3.exe"
-  New-Item -ItemType SymbolicLink -Path $python3 -Target $python -ErrorAction SilentlyContinue
-}
-
 # Installing Python dependencies
 $dev = If ($Env:GITHUB_JOB -eq 'Build') { '' } Else { '-dev' }
 # Ensures installation tools are up to date. This also aliases pip to pip3 on MacOS.
-python3 -m pip install wheel pip setuptools --upgrade
+python -m pip install wheel pip setuptools --upgrade
 pip install -r "$PSScriptRoot/requirements$dev.txt" --upgrade
 
 # Don't compile resources on the Build CI job as it'll do so in build script

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -15,12 +15,12 @@ ruff>=0.0.262 # Avoid N802 violations for @override + Avoid adding required impo
 # Can also be downloaded externally as a non-python package
 # qt6-applications
 # Types
-types-d3dshot
+types-D3DShot ; sys_platform == 'win32'
 types-keyboard
 types-Pillow
 types-psutil
 types-PyAutoGUI
 types-pyinstaller
-types-pywin32
+types-pywin32 ; sys_platform == 'win32'
 types-requests
 types-toml

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -21,6 +21,7 @@ packaging
 Pillow>=9.2  # gnome-screeshot checks
 psutil
 PyAutoGUI
+PyWinCtl>=0.0.42 # py.typed
 PySide6-Essentials>=6.5 # fixes https://bugreports.qt.io/browse/PYSIDE-2189 and https://bugreports.qt.io/browse/PYSIDE-1603
 requests<=2.28.1  # 2.28.2 has issues with PyInstaller https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/534
 toml

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -1,3 +1,3 @@
 param ([string]$p1)
 & "$PSScriptRoot/compile_resources.ps1"
-python3 "$PSScriptRoot/../src/AutoSplit.py" $p1
+python "$PSScriptRoot/../src/AutoSplit.py" $p1

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -56,7 +56,7 @@ DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = 2
 os.environ["REQUESTS_CA_BUNDLE"] = certifi.where()
 myappid = f"Toufool.AutoSplit.v{AUTOSPLIT_VERSION}"
 ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
-# qt.qpa.window: SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) failed: COM error 0x5: Access is denied.  # noqa: E501  # pylint: disable=line-too-long
+# qt.qpa.window: SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) failed: COM error 0x5: Access is denied.  # noqa: E501
 # ctypes.windll.user32.SetProcessDpiAwarenessContext(2)
 
 

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -432,7 +432,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             or self.split_image_number > len(self.split_images_and_loop_number) - 1
 
     def undo_split(self, navigate_image_only: bool = False):
-        """"Undo Split" and "Prev. Img." buttons connect to here."""
+        """Undo Split" and "Prev. Img." buttons connect to here."""
         # Can't undo until timer is started
         # or Undoing past the first image
         if not self.is_running \
@@ -454,7 +454,7 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
             send_command(self, "undo")
 
     def skip_split(self, navigate_image_only: bool = False):
-        """"Skip Split" and "Next Img." buttons connect to here."""
+        """Skip Split" and "Next Img." buttons connect to here."""
         # Can't skip or split until timer is started
         # or Splitting/skipping when there are no images left
         if not self.is_running \

--- a/src/capture_method/BitBltCaptureMethod.py
+++ b/src/capture_method/BitBltCaptureMethod.py
@@ -22,6 +22,14 @@ PW_RENDERFULLCONTENT = 0x00000002
 
 
 class BitBltCaptureMethod(CaptureMethodBase):
+    name = "BitBlt"
+    short_description = "fastest, least compatible"
+    description = (
+        "\nThe best option when compatible. But it cannot properly record "
+        + "\nOpenGL, Hardware Accelerated or Exclusive Fullscreen windows. "
+        + "\nThe smaller the selected region, the more efficient it is. "
+    )
+
     _render_full_content = False
 
     def get_frame(self, autosplit: AutoSplit) -> tuple[cv2.Mat | None, bool]:

--- a/src/capture_method/CaptureMethodBase.py
+++ b/src/capture_method/CaptureMethodBase.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
 
 
 class CaptureMethodBase():
+    name = "None"
+    short_description = ""
+    description = ""
+
     def __init__(self, autosplit: AutoSplit | None = None):
         # Some capture methods don't need an initialization process
         pass

--- a/src/capture_method/DesktopDuplicationCaptureMethod.py
+++ b/src/capture_method/DesktopDuplicationCaptureMethod.py
@@ -9,13 +9,25 @@ import win32con
 from win32 import win32gui
 
 from capture_method.BitBltCaptureMethod import BitBltCaptureMethod
-from utils import get_window_bounds
+from utils import GITHUB_REPOSITORY, get_window_bounds
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
 
 
 class DesktopDuplicationCaptureMethod(BitBltCaptureMethod):
+    name = "Direct3D Desktop Duplication"
+    short_description = "slower, bound to display"
+    description = (
+        "\nDuplicates the desktop using Direct3D. "
+        + "\nIt can record OpenGL and Hardware Accelerated windows. "
+        + "\nAbout 10-15x slower than BitBlt. Not affected by window size. "
+        + "\nOverlapping windows will show up and can't record across displays. "
+        + "\nThis option may not be available for hybrid GPU laptops, "
+        + "\nsee D3DDD-Note-Laptops.md for a solution. "
+        + f"\nhttps://www.github.com/{GITHUB_REPOSITORY}#capture-method "
+    )
+
     def __init__(self):
         super().__init__()
         # Must not set statically as some laptops will throw an error

--- a/src/capture_method/ForceFullContentRenderingCaptureMethod.py
+++ b/src/capture_method/ForceFullContentRenderingCaptureMethod.py
@@ -4,4 +4,12 @@ from capture_method.BitBltCaptureMethod import BitBltCaptureMethod
 
 
 class ForceFullContentRenderingCaptureMethod(BitBltCaptureMethod):
+    name = "Force Full Content Rendering"
+    short_description = "very slow, can affect rendering"
+    description = (
+        "\nUses BitBlt behind the scene, but passes a special flag "
+        + "\nto PrintWindow to force rendering the entire desktop. "
+        + "\nAbout 10-15x slower than BitBlt based on original window size "
+        + "\nand can mess up some applications' rendering pipelines. "
+    )
     _render_full_content = True

--- a/src/capture_method/VideoCaptureDeviceCaptureMethod.py
+++ b/src/capture_method/VideoCaptureDeviceCaptureMethod.py
@@ -25,6 +25,15 @@ def is_blank(image: cv2.Mat):
 
 
 class VideoCaptureDeviceCaptureMethod(CaptureMethodBase):
+    name = "Video Capture Device"
+    short_description = "see below"
+    description = (
+        "\nUses a Video Capture Device, like a webcam, virtual cam, or capture card. "
+        + "\nYou can select one below. "
+        + "\nIf you want to use this with OBS' Virtual Camera, use the Virtualcam plugin instead "
+        + "\nhttps://github.com/Avasam/obs-virtual-cam/releases"
+    )
+
     capture_device: cv2.VideoCapture
     capture_thread: Thread | None
     stop_thread: Event
@@ -113,9 +122,6 @@ class VideoCaptureDeviceCaptureMethod(CaptureMethodBase):
             x:x + selection["width"],
         ]
         return cv2.cvtColor(image, cv2.COLOR_BGR2BGRA), is_old_image
-
-    def recover_window(self, captured_window_title: str, autosplit: AutoSplit) -> bool:
-        raise NotImplementedError
 
     def check_selected_region_exists(self, autosplit: AutoSplit):
         return bool(self.capture_device.isOpened())

--- a/src/capture_method/WindowsGraphicsCaptureMethod.py
+++ b/src/capture_method/WindowsGraphicsCaptureMethod.py
@@ -13,15 +13,28 @@ from winsdk.windows.graphics.directx import DirectXPixelFormat
 from winsdk.windows.graphics.imaging import BitmapBufferAccessMode, SoftwareBitmap
 
 from capture_method.CaptureMethodBase import CaptureMethodBase
-from utils import RGBA_CHANNEL_COUNT, WINDOWS_BUILD_NUMBER, get_direct3d_device, is_valid_hwnd
+from utils import RGBA_CHANNEL_COUNT, WGC_MIN_BUILD, WINDOWS_BUILD_NUMBER, get_direct3d_device, is_valid_hwnd
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
 
 WGC_NO_BORDER_MIN_BUILD = 20348
+LEARNING_MODE_DEVICE_BUILD = 17763
+"""https://learn.microsoft.com/en-us/uwp/api/windows.ai.machinelearning.learningmodeldevice"""
 
 
 class WindowsGraphicsCaptureMethod(CaptureMethodBase):
+    name = "Windows Graphics Capture"
+    short_description = "fast, most compatible, capped at 60fps"
+    description = (
+        f"\nOnly available in Windows 10.0.{WGC_MIN_BUILD} and up. "
+        + f"\nDue to current technical limitations, Windows versions below 10.0.0.{LEARNING_MODE_DEVICE_BUILD}"
+        + "\nrequire having at least one audio or video Capture Device connected and enabled."
+        + "\nAllows recording UWP apps, Hardware Accelerated and Exclusive Fullscreen windows. "
+        + "\nAdds a yellow border on Windows 10 (not on Windows 11)."
+        + "\nCaps at around 60 FPS. "
+    )
+
     size: SizeInt32
     frame_pool: Direct3D11CaptureFramePool | None = None
     session: GraphicsCaptureSession | None = None

--- a/src/capture_method/__init__.py
+++ b/src/capture_method/__init__.py
@@ -15,15 +15,10 @@ from capture_method.DesktopDuplicationCaptureMethod import DesktopDuplicationCap
 from capture_method.ForceFullContentRenderingCaptureMethod import ForceFullContentRenderingCaptureMethod
 from capture_method.VideoCaptureDeviceCaptureMethod import VideoCaptureDeviceCaptureMethod
 from capture_method.WindowsGraphicsCaptureMethod import WindowsGraphicsCaptureMethod
-from utils import GITHUB_REPOSITORY, WINDOWS_BUILD_NUMBER, first, try_get_direct3d_device
+from utils import WGC_MIN_BUILD, WINDOWS_BUILD_NUMBER, first, try_get_direct3d_device
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
-
-WGC_MIN_BUILD = 17134
-"""https://docs.microsoft.com/en-us/uwp/api/windows.graphics.capture.graphicscapturepicker#applies-to"""
-LEARNING_MODE_DEVICE_BUILD = 17763
-"""https://learn.microsoft.com/en-us/uwp/api/windows.ai.machinelearning.learningmodeldevice"""
 
 
 class Region(TypedDict):
@@ -31,14 +26,6 @@ class Region(TypedDict):
     y: int
     width: int
     height: int
-
-
-@dataclass
-class CaptureMethodInfo():
-    name: str
-    short_description: str
-    description: str
-    implementation: type[CaptureMethodBase]
 
 
 class CaptureMethodMeta(EnumMeta):
@@ -74,7 +61,7 @@ class CaptureMethodEnum(Enum, metaclass=CaptureMethodMeta):
     VIDEO_CAPTURE_DEVICE = "VIDEO_CAPTURE_DEVICE"
 
 
-class CaptureMethodDict(OrderedDict[CaptureMethodEnum, CaptureMethodInfo]):
+class CaptureMethodDict(OrderedDict[CaptureMethodEnum, type[CaptureMethodBase]]):
     def get_index(self, capture_method: str | CaptureMethodEnum):
         """Returns 0 if the capture_method is invalid or unsupported."""
         try:
@@ -99,21 +86,14 @@ class CaptureMethodDict(OrderedDict[CaptureMethodEnum, CaptureMethodInfo]):
 
     def get(self, __key: CaptureMethodEnum):
         """
-        Returns the `CaptureMethodInfo` for `CaptureMethodEnum` if `CaptureMethodEnum` is available,
+        Returns the `CaptureMethodBase` subclass for `CaptureMethodEnum` if `CaptureMethodEnum` is available,
         else defaults to the first available `CaptureMethodEnum`.
-        Returns the `CaptureMethodBase` (default) implementation if there's no capture methods.
+        Returns `CaptureMethodBase` (default) directly if there's no capture methods.
         """
         if __key == CaptureMethodEnum.NONE or len(self) <= 0:
-            return NONE_CAPTURE_METHOD
+            return CaptureMethodBase
         return super().get(__key, first(self.values()))
 
-
-NONE_CAPTURE_METHOD = CaptureMethodInfo(
-    name="None",
-    short_description="",
-    description="",
-    implementation=CaptureMethodBase,
-)
 
 CAPTURE_METHODS = CaptureMethodDict()
 if (  # Windows Graphics Capture requires a minimum Windows Build
@@ -121,77 +101,22 @@ if (  # Windows Graphics Capture requires a minimum Windows Build
     # Our current implementation of Windows Graphics Capture does not ensure we can get an ID3DDevice
     and try_get_direct3d_device()
 ):
-    CAPTURE_METHODS[CaptureMethodEnum.WINDOWS_GRAPHICS_CAPTURE] = CaptureMethodInfo(
-        name="Windows Graphics Capture",
-        short_description="fast, most compatible, capped at 60fps",
-        description=(
-            f"\nOnly available in Windows 10.0.{WGC_MIN_BUILD} and up. "
-            + f"\nDue to current technical limitations, Windows versions below 10.0.0.{LEARNING_MODE_DEVICE_BUILD}"
-            + "\nrequire having at least one audio or video Capture Device connected and enabled."
-            + "\nAllows recording UWP apps, Hardware Accelerated and Exclusive Fullscreen windows. "
-            + "\nAdds a yellow border on Windows 10 (not on Windows 11)."
-            + "\nCaps at around 60 FPS. "
-        ),
-        implementation=WindowsGraphicsCaptureMethod,
-    )
-CAPTURE_METHODS[CaptureMethodEnum.BITBLT] = CaptureMethodInfo(
-    name="BitBlt",
-    short_description="fastest, least compatible",
-    description=(
-        "\nThe best option when compatible. But it cannot properly record "
-        + "\nOpenGL, Hardware Accelerated or Exclusive Fullscreen windows. "
-        + "\nThe smaller the selected region, the more efficient it is. "
-    ),
-
-    implementation=BitBltCaptureMethod,
-)
+    CAPTURE_METHODS[CaptureMethodEnum.WINDOWS_GRAPHICS_CAPTURE] = WindowsGraphicsCaptureMethod
+CAPTURE_METHODS[CaptureMethodEnum.BITBLT] = BitBltCaptureMethod
 try:
     import d3dshot
     d3dshot.create(capture_output="numpy")
 except (ModuleNotFoundError, COMError):
     pass
 else:
-    CAPTURE_METHODS[CaptureMethodEnum.DESKTOP_DUPLICATION] = CaptureMethodInfo(
-        name="Direct3D Desktop Duplication",
-        short_description="slower, bound to display",
-        description=(
-            "\nDuplicates the desktop using Direct3D. "
-            + "\nIt can record OpenGL and Hardware Accelerated windows. "
-            + "\nAbout 10-15x slower than BitBlt. Not affected by window size. "
-            + "\nOverlapping windows will show up and can't record across displays. "
-            + "\nThis option may not be available for hybrid GPU laptops, "
-            + "\nsee D3DDD-Note-Laptops.md for a solution. "
-            + f"\nhttps://www.github.com/{GITHUB_REPOSITORY}#capture-method "
-        ),
-        implementation=DesktopDuplicationCaptureMethod,
-    )
-CAPTURE_METHODS[CaptureMethodEnum.PRINTWINDOW_RENDERFULLCONTENT] = CaptureMethodInfo(
-    name="Force Full Content Rendering",
-    short_description="very slow, can affect rendering",
-    description=(
-        "\nUses BitBlt behind the scene, but passes a special flag "
-        + "\nto PrintWindow to force rendering the entire desktop. "
-        + "\nAbout 10-15x slower than BitBlt based on original window size "
-        + "\nand can mess up some applications' rendering pipelines. "
-    ),
-    implementation=ForceFullContentRenderingCaptureMethod,
-)
-CAPTURE_METHODS[CaptureMethodEnum.VIDEO_CAPTURE_DEVICE] = CaptureMethodInfo(
-    name="Video Capture Device",
-    short_description="see below",
-    description=(
-        "\nUses a Video Capture Device, like a webcam, virtual cam, or capture card. "
-        + "\nYou can select one below. "
-        + "\nIf you want to use this with OBS' Virtual Camera, use the Virtualcam plugin instead "
-        + "\nhttps://github.com/Avasam/obs-virtual-cam/releases"
-    ),
-    implementation=VideoCaptureDeviceCaptureMethod,
-)
+    CAPTURE_METHODS[CaptureMethodEnum.DESKTOP_DUPLICATION] = DesktopDuplicationCaptureMethod
+CAPTURE_METHODS[CaptureMethodEnum.PRINTWINDOW_RENDERFULLCONTENT] = ForceFullContentRenderingCaptureMethod
+CAPTURE_METHODS[CaptureMethodEnum.VIDEO_CAPTURE_DEVICE] = VideoCaptureDeviceCaptureMethod
 
 
 def change_capture_method(selected_capture_method: CaptureMethodEnum, autosplit: AutoSplit):
     autosplit.capture_method.close(autosplit)
-    autosplit.capture_method = CAPTURE_METHODS.get(selected_capture_method).implementation(autosplit)
+    autosplit.capture_method = CAPTURE_METHODS.get(selected_capture_method)(autosplit)
     if selected_capture_method == CaptureMethodEnum.VIDEO_CAPTURE_DEVICE:
         autosplit.select_region_button.setDisabled(True)
         autosplit.select_window_button.setDisabled(True)
@@ -209,6 +134,11 @@ class CameraInfo():
     resolution: tuple[int, int] | None
 
 
+def get_input_devices():
+    # https://github.com/andreaschiavinato/python_grabber/pull/24
+    return cast(list[str], FilterGraph().get_input_devices())
+
+
 def get_input_device_resolution(index: int):
     filter_graph = FilterGraph()
     filter_graph.add_video_input_device(index)
@@ -218,8 +148,7 @@ def get_input_device_resolution(index: int):
 
 
 async def get_all_video_capture_devices() -> list[CameraInfo]:
-    # TODO: Fix partially Unknown list upstream
-    named_video_inputs: list[str] = FilterGraph().get_input_devices()
+    named_video_inputs = get_input_devices()
 
     async def get_camera_info(index: int, device_name: str):
         backend = ""
@@ -242,7 +171,8 @@ async def get_all_video_capture_devices() -> list[CameraInfo]:
 
         return CameraInfo(index, device_name, False, backend, get_input_device_resolution(index))
 
-    future = asyncio.gather(
+    # https://github.com/python/typeshed/issues/2652
+    future: asyncio.Future[list[CameraInfo | None]] = asyncio.gather(
         *[
             get_camera_info(index, name) for index, name
             in enumerate(named_video_inputs)

--- a/src/hotkeys.py
+++ b/src/hotkeys.py
@@ -105,7 +105,7 @@ def __validate_keypad(expected_key: str, keyboard_event: keyboard.KeyboardEvent)
     NOTE: This is a workaround very specific to numpads.
     Windows reports different physical keys with the same scan code.
     For example, "Home", "Num Home" and "Num 7" are all `71`.
-    See: https://github.com/boppreh/keyboard/issues/171#issuecomment-390437684.
+    See: https://github.com/boppreh/keyboard/issues/171#issuecomment-390437684 .
 
     Since we reuse the key string we set to send to LiveSplit, we can't use fake names like "num home".
     We're also trying to achieve the same hotkey behaviour as LiveSplit has.
@@ -153,7 +153,7 @@ def __get_key_name(keyboard_event: keyboard.KeyboardEvent):
 def __get_hotkey_name(names: list[str]):
     """
     Uses keyboard.get_hotkey_name but works with non-english modifiers and keypad
-    See: https://github.com/boppreh/keyboard/issues/516.
+    See: https://github.com/boppreh/keyboard/issues/516 .
     """
     def sorting_key(key: str):
         return not keyboard.is_modifier(keyboard.key_to_scan_codes(key)[0])

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -14,7 +14,7 @@ from pywinctl import getTopWindowAt
 from typing_extensions import override
 from win32 import win32gui
 from win32con import SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN
-from winsdk._winrt import initialize_with_window  # pylint: disable=no-name-in-module
+from winsdk._winrt import initialize_with_window
 from winsdk.windows.foundation import AsyncStatus, IAsyncOperation
 from winsdk.windows.graphics.capture import GraphicsCaptureItem, GraphicsCapturePicker
 

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -10,6 +10,7 @@ import cv2
 import numpy as np
 from PySide6 import QtCore, QtGui, QtWidgets
 from PySide6.QtTest import QTest
+from pywinctl import getTopWindowAt
 from typing_extensions import override
 from win32 import win32gui
 from win32con import SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN
@@ -18,7 +19,7 @@ from winsdk.windows.foundation import AsyncStatus, IAsyncOperation
 from winsdk.windows.graphics.capture import GraphicsCaptureItem, GraphicsCapturePicker
 
 import error_messages
-from utils import MAXBYTE, get_window_bounds, getTopWindowAt, is_valid_hwnd, is_valid_image
+from utils import MAXBYTE, get_window_bounds, is_valid_hwnd, is_valid_image
 
 user32 = ctypes.windll.user32
 
@@ -327,7 +328,7 @@ class SelectWindowWidget(BaseSelectWidget):
 class SelectRegionWidget(BaseSelectWidget):
     """
     Widget for dragging screen region
-    https://github.com/harupy/snipping-tool.
+    Originated from https://github.com/harupy/snipping-tool .
     """
 
     _right: int = 0

--- a/src/user_profile.py
+++ b/src/user_profile.py
@@ -202,7 +202,9 @@ def load_check_for_updates_on_open(autosplit: AutoSplit):
     value = QtCore \
         .QSettings("AutoSplit", "Check For Updates On Open") \
         .value("check_for_updates_on_open", True, type=bool)
-    autosplit.action_check_for_updates_on_open.setChecked(value)  # pyright: ignore[reportGeneralTypeIssues]  # Type not infered by PySide6  # noqa: E501  # pylint: disable=line-too-long
+    # Type not infered by PySide6
+    # TODO: Report this issue upstream
+    autosplit.action_check_for_updates_on_open.setChecked(value)  # pyright: ignore[reportGeneralTypeIssues]
 
 
 def set_check_for_updates_on_open(design_window: design.Ui_MainWindow, value: bool):

--- a/src/utils.py
+++ b/src/utils.py
@@ -141,7 +141,8 @@ def fire_and_forget(func: Callable[..., Any]):
     """
     Runs synchronous function asynchronously without waiting for a response.
 
-    Uses threads on Windows because `RuntimeError: There is no current event loop in thread 'MainThread'.`
+    Uses threads on Windows because ~~`RuntimeError: There is no current event loop in thread 'MainThread'.`~~
+    Because maybe asyncio has issues. Unsure. See alpha.5 and https://github.com/Avasam/AutoSplit/issues/36
 
     Uses asyncio on Linux because of a `Segmentation fault (core dumped)`
     """
@@ -155,31 +156,12 @@ def fire_and_forget(func: Callable[..., Any]):
     return wrapped
 
 
-def getTopWindowAt(x: int, y: int):  # noqa: N802
-    # Immitating PyWinCTL's function
-    class Win32Window():
-        def __init__(self, hwnd: int) -> None:
-            self._hWnd = hwnd
-
-        def getHandle(self):  # noqa: N802
-            return self._hWnd
-
-        @property
-        def title(self):
-            return win32gui.GetWindowText(self._hWnd)
-    hwnd = win32gui.WindowFromPoint((x, y))
-
-    # Want to pull the parent window from the window handle
-    # By using GetAncestor we are able to get the parent window instead of the owner window.
-    while win32gui.IsChild(win32gui.GetParent(hwnd), hwnd):
-        hwnd = ctypes.windll.user32.GetAncestor(hwnd, 2)
-    return Win32Window(hwnd) if hwnd else None
-
-
 # Environment specifics
 WINDOWS_BUILD_NUMBER = int(version().split(".")[-1]) if sys.platform == "win32" else -1
 FIRST_WIN_11_BUILD = 22000
 """AutoSplit Version number"""
+WGC_MIN_BUILD = 17134
+"""https://docs.microsoft.com/en-us/uwp/api/windows.graphics.capture.graphicscapturepicker#applies-to"""
 FROZEN = hasattr(sys, "frozen")
 """Running from build made by PyInstaller"""
 auto_split_directory = os.path.dirname(sys.executable if FROZEN else os.path.abspath(__file__))

--- a/typings/cv2/mat_wrapper/__init__.pyi
+++ b/typings/cv2/mat_wrapper/__init__.pyi
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 from typing_extensions import TypeAlias
 


### PR DESCRIPTION
- Comments updates
- Scripts updates
- Use PyWinCtl
- No longer build releases on 3.10
- Change default formatter in VSCode to autopep8
- `xml.format.preserveSpace` for `<string>`
- UI more spaced out (support Win11 high-DPI and Linux)
- Scope Capture Methods descriptions to classes by using ClassVars