### PR TITLE
Respect the system's palette on Windows (darkmode)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,9 @@ repos:
     rev: v2.4.0 # Must match requirements-dev.txt
     hooks:
       - id: add-trailing-comma
+
+ci:
+  skip:
+    # Ignore until Linux support. We don't want lf everywhere yet
+    # And crlf fails on CI because pre-commit runs on linux
+    - "mixed-line-ending"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ ignore = [
 
   ### FIXME (no warnings in Ruff yet: https://github.com/charliermarsh/ruff/issues/1256):
   "PTH",
+  # Ignore until linux support
+  "EXE",
 ]
 
 [tool.ruff.per-file-ignores]

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -949,6 +949,9 @@ def is_already_open():
 
 
 def main():
+    # Best to call setStyle before the QApplication constructor
+    # https://doc.qt.io/qt-6/qapplication.html#setStyle-1
+    QApplication.setStyle("fusion")
     # Call to QApplication outside the try-except so we can show error messages
     app = QApplication(sys.argv)
     try:

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -38,16 +38,7 @@ from menu_bar import (
 from region_selection import align_region, select_region, select_window, validate_before_parsing
 from split_parser import BELOW_FLAG, DUMMY_FLAG, PAUSE_FLAG, parse_and_validate_images
 from user_profile import DEFAULT_PROFILE
-from utils import (
-    AUTOSPLIT_VERSION,
-    FIRST_WIN_11_BUILD,
-    FROZEN,
-    WINDOWS_BUILD_NUMBER,
-    auto_split_directory,
-    decimal,
-    is_valid_image,
-    open_file,
-)
+from utils import AUTOSPLIT_VERSION, FROZEN, auto_split_directory, decimal, is_valid_image, open_file
 
 CHECK_FPS_ITERATIONS = 10
 DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = 2
@@ -127,14 +118,6 @@ class AutoSplit(QMainWindow, design.Ui_MainWindow):
 
         self.setupUi(self)
         self.setWindowTitle(f"AutoSplit v{AUTOSPLIT_VERSION}")
-        # Spinbox frame disappears and reappears on Windows 11. It's much cleaner to just disable them.
-        # Most likely related: https://bugreports.qt.io/browse/QTBUG-95215?jql=labels%20%3D%20Windows11
-        # Arrow buttons tend to move a lot as well
-        if WINDOWS_BUILD_NUMBER >= FIRST_WIN_11_BUILD:
-            self.x_spinbox.setFrame(False)
-            self.y_spinbox.setFrame(False)
-            self.width_spinbox.setFrame(False)
-            self.height_spinbox.setFrame(False)
 
         # Hotkeys need to be initialized to be passed as thread arguments in hotkeys.py
         for hotkey in HOTKEYS:

--- a/src/menu_bar.py
+++ b/src/menu_bar.py
@@ -20,14 +20,7 @@ from capture_method import (
 )
 from gen import about, design, settings as settings_ui, update_checker
 from hotkeys import HOTKEYS, Hotkey, set_hotkey
-from utils import (
-    AUTOSPLIT_VERSION,
-    FIRST_WIN_11_BUILD,
-    GITHUB_REPOSITORY,
-    WINDOWS_BUILD_NUMBER,
-    decimal,
-    fire_and_forget,
-)
+from utils import AUTOSPLIT_VERSION, GITHUB_REPOSITORY, decimal, fire_and_forget
 
 if TYPE_CHECKING:
     from AutoSplit import AutoSplit
@@ -198,16 +191,6 @@ class __SettingsWidget(QtWidgets.QWidget, settings_ui.Ui_SettingsWidget):  # noq
         else:
             self.capture_device_combobox.setPlaceholderText("No device found.")
 
-    def __apply_os_specific_ui_fixes(self):
-        # Spinbox frame disappears and reappears on Windows 11. It's much cleaner to just disable them.
-        # Most likely related: https://bugreports.qt.io/browse/QTBUG-95215?jql=labels%20%3D%20Windows11
-        # Arrow buttons tend to move a lot as well
-        if WINDOWS_BUILD_NUMBER >= FIRST_WIN_11_BUILD:
-            self.fps_limit_spinbox.setFrame(False)
-            self.default_similarity_threshold_spinbox.setFrame(False)
-            self.default_delay_time_spinbox.setFrame(False)
-            self.default_pause_time_spinbox.setFrame(False)
-
     def __set_readme_link(self):
         self.custom_image_settings_info_label.setText(
             self.custom_image_settings_info_label
@@ -225,7 +208,6 @@ class __SettingsWidget(QtWidgets.QWidget, settings_ui.Ui_SettingsWidget):  # noq
         super().__init__()
         self.setupUi(self)
         self.autosplit = autosplit
-        self.__apply_os_specific_ui_fixes()
         self.__set_readme_link()
         # Don't autofocus any particular field
         self.setFocus()


### PR DESCRIPTION
Closes #209

It even changes live without having to reboot autosplit. I can also remove a UI hack for Windows 11.
The red and orange outlines are because I set my accent color to red and orange in Windows 10 and 11 respectively.

Windows 10 fusion light
![image](https://user-images.githubusercontent.com/1350584/233756850-30a24bab-a4a9-48be-8f21-5cba2fe719ec.png)

Windows 10 fusion dark
![image](https://user-images.githubusercontent.com/1350584/233756893-d665f778-6526-42a9-83a0-3f94884b74aa.png)

Windows 11 fusion light
![f5312fc2-a522-441a-b86a-8fb339fdbd86](https://user-images.githubusercontent.com/1350584/233757216-c96325f9-0f03-49a8-adae-707010142c70.jpg)

Windows 11 fusion dark
![34ad4a33-f077-42b8-986f-3d33c6b761af](https://user-images.githubusercontent.com/1350584/233757219-7562c879-8704-4cb8-be35-a6c2ae18a270.jpg)
