### PR TITLE
Backport improved spacing from dev

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,22 +1,22 @@
 [flake8]
-color=always
-max-line-length=120
+color = always
+max-line-length = 120
 ; Auto generated
-exclude=src/gen/, typings/cv2-stubs/__init__.pyi
-ignore=
-  ; Linebreak before binary operator
-  W503,
-  ; Closing bracket may not match multi-line method invocation style (enforced by add-trailing-comma)
-  E124,
-  ; Allow imports at the bottom of file
-  E402,
-  ; Not using typing_extensions
-  Y026,
-  ; contextlib.suppress is roughly 3x slower than try/except
-  SIM105,
-  ; False positives for attribute docstrings
-  CCE001,
-per-file-ignores=
+exclude = src/gen/, typings/cv2-stubs/__init__.pyi
+ignore =
+    ; Linebreak before binary operator
+    W503,
+    ; Closing bracket may not match multi-line method invocation style (enforced by add-trailing-comma)
+    E124,
+    ; Allow imports at the bottom of file
+    E402,
+    ; Not using typing_extensions
+    Y026,
+    ; contextlib.suppress is roughly 3x slower than try/except
+    SIM105,
+    ; False positives for attribute docstrings
+    CCE001,
+per-file-ignores =
     ; Quotes
     ; Allow ... on same line as class
     ; Allow ... on same line as def
@@ -30,8 +30,8 @@ per-file-ignores=
     ; mypy 3.7 Union issue
     *.pyi: Q000,E701,E704,E501,N8,A001,A002,A003,CCE002,F401,Y037
 ; PyQt methods
-ignore-names=closeEvent,paintEvent,keyPressEvent,mousePressEvent,mouseMoveEvent,mouseReleaseEvent
+ignore-names = closeEvent,paintEvent,keyPressEvent,mousePressEvent,mouseMoveEvent,mouseReleaseEvent
 ; McCabe max-complexity is also taken care of by Pylint and doesn't fail the build there
 ; So this is the hard limit
-max-complexity=32
-inline-quotes=double
+max-complexity = 32
+inline-quotes = double

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,12 @@ repos:
     hooks:
       - id: pretty-format-ini
         args: [--autofix]
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.262" # Must match requirements-dev.txt
-    hooks:
-      - id: ruff
-        args: [--fix]
+  # TODO: Re-enable in dev, master doesn't have Ruff configs
+  # - repo: https://github.com/charliermarsh/ruff-pre-commit
+  #   rev: "v0.0.262" # Must match requirements-dev.txt
+  #   hooks:
+  #     - id: ruff
+  #       args: [--fix]
   - repo: https://github.com/pre-commit/mirrors-autopep8
     rev: "v2.0.2" # Must match requirements-dev.txt
     hooks:
@@ -30,7 +31,7 @@ repos:
     rev: v2.4.0 # Must match requirements-dev.txt
     hooks:
       - id: add-trailing-comma
-      
+
 ci:
   skip:
     # Ignore until Linux support. We don't want lf everywhere yet

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -141,4 +141,18 @@
   "terminal.integrated.defaultProfile.windows": "PowerShell",
   "xml.codeLens.enabled": true,
   "xml.format.spaceBeforeEmptyCloseTag": false,
+  "xml.format.preserveSpace": [
+    // Default
+    "xsl:text",
+    "xsl:comment",
+    "xsl:processing-instruction",
+    "literallayout",
+    "programlisting",
+    "screen",
+    "synopsis",
+    "pre",
+    "xd:pre",
+    // Custom
+    "string"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ If this option is disabled, when the reset hotkey is hit, the reset button is pr
   - `002_SplitName_(0.9)_[10]_{d}.png` is the second split image with a threshold of 0.9, pause time of 10, and is a dummy split.
   - `003_SplitName_(0.85)_[20]_#3500#.png` is the third split image with a threshold of 0.85, pause time of 20 and has a delay split time of 3.5 seconds.
   - `004_SplitName_(0.9)_[10]_#3500#_@3@_{b}.png` is the fourth split image with a threshold of 0.9, pause time of 10 seconds, delay split time of 3.5 seconds, will loop 3 times, and will split when similarity is below the threshold rather than above.
-  
+
 ## Special images
 
 ### How to Create a Masked Image

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,21 +1,21 @@
 ; We don't run mypy in the CI. This is just to help anyone who would like to use it manually.
 ; Namely, the mypy_primer tool.
 [mypy]
-strict=true
+strict = true
 ; Implicit return types !
-disallow_untyped_calls=false
-disallow_untyped_defs=false
-disallow_incomplete_defs=false
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
 
 ; Of course my stubs are going to be incomplete. Otherwise they'd be on typeshed!
 ; Mypy becomes really whack with its errors inside these stubs though
-mypy_path=typings,src
+mypy_path = typings,src
 ; exclude doesn't work with strict=true Why?
-exclude=.*(typings|gen)/.*
+exclude = .*(typings|gen)/.*
 
 [mypy-gen.*,cv2.*,]
 ; strict=false ; Doesn't work in overrides
-follow_imports=skip
-implicit_reexport=true
-strict_optional=false
-disable_error_code=attr-defined, misc, name-defined
+follow_imports = skip
+implicit_reexport = true
+strict_optional = false
+disable_error_code = attr-defined, misc, name-defined

--- a/res/about.ui
+++ b/res/about.ui
@@ -32,9 +32,7 @@
   </property>
   <property name="windowIcon">
    <iconset resource="resources.qrc">
-    <normaloff>:/resources/icon.ico</normaloff>
-    :/resources/icon.ico
-   </iconset>
+    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
   </property>
   <widget class="QPushButton" name="ok_button">
    <property name="geometry">
@@ -81,7 +79,7 @@
      <x>10</x>
      <y>90</y>
      <width>241</width>
-     <height>41</height>
+     <height>51</height>
     </rect>
    </property>
    <property name="text">
@@ -103,7 +101,7 @@ Thank you!</string>
     </rect>
    </property>
    <property name="text">
-    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.paypal.com/cgi-bin/webscr?cmd=_donations&amp;amp;business=BYRHQG69YRHBA&amp;amp;item_name=AutoSplit+development&amp;amp;currency_code=USD&amp;amp;source=url&quot;&gt;&lt;img src=&quot;:/resources/btn_donateCC_LG.png&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    <string/>
    </property>
    <property name="pixmap">
     <pixmap resource="resources.qrc">:/resources/btn_donateCC_LG.png</pixmap>
@@ -115,7 +113,7 @@ Thank you!</string>
   <widget class="QLabel" name="icon_label">
    <property name="geometry">
     <rect>
-     <x>181</x>
+     <x>190</x>
      <y>17</y>
      <width>64</width>
      <height>64</height>

--- a/res/about.ui
+++ b/res/about.ui
@@ -101,10 +101,7 @@ Thank you!</string>
     </rect>
    </property>
    <property name="text">
-    <string/>
-   </property>
-   <property name="pixmap">
-    <pixmap resource="resources.qrc">:/resources/btn_donateCC_LG.png</pixmap>
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.paypal.com/cgi-bin/webscr?cmd=_donations&amp;amp;business=BYRHQG69YRHBA&amp;amp;item_name=AutoSplit+development&amp;amp;currency_code=USD&amp;amp;source=url&quot;&gt;&lt;img src=&quot;:/resources/btn_donateCC_LG.png&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignCenter</set>

--- a/res/design.ui
+++ b/res/design.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>777</width>
-    <height>424</height>
+    <width>786</width>
+    <height>426</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>777</width>
-    <height>424</height>
+    <width>786</width>
+    <height>426</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>777</width>
-    <height>424</height>
+    <width>786</width>
+    <height>426</height>
    </size>
   </property>
   <property name="font">
@@ -32,17 +32,15 @@
   </property>
   <property name="windowIcon">
    <iconset resource="resources.qrc">
-    <normaloff>:/resources/icon.ico</normaloff>
-    :/resources/icon.ico
-   </iconset>
+    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
   </property>
   <widget class="QWidget" name="central_widget">
    <widget class="QLabel" name="x_label">
     <property name="geometry">
      <rect>
       <x>11</x>
-      <y>143</y>
-      <width>44</width>
+      <y>145</y>
+      <width>49</width>
       <height>20</height>
      </rect>
     </property>
@@ -58,8 +56,8 @@
      <rect>
       <x>10</x>
       <y>67</y>
-      <width>101</width>
-      <height>23</height>
+      <width>107</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -72,7 +70,7 @@
    <widget class="QPushButton" name="start_auto_splitter_button">
     <property name="geometry">
      <rect>
-      <x>650</x>
+      <x>657</x>
       <y>369</y>
       <width>121</width>
       <height>27</height>
@@ -91,7 +89,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>650</x>
+      <x>657</x>
       <y>339</y>
       <width>121</width>
       <height>27</height>
@@ -110,7 +108,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>650</x>
+      <x>657</x>
       <y>310</y>
       <width>59</width>
       <height>27</height>
@@ -129,7 +127,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>712</x>
+      <x>719</x>
       <y>310</y>
       <width>59</width>
       <height>27</height>
@@ -146,9 +144,9 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>253</y>
+      <y>270</y>
       <width>53</width>
-      <height>23</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -165,8 +163,8 @@
     <property name="geometry">
      <rect>
       <x>92</x>
-      <y>254</y>
-      <width>20</width>
+      <y>272</y>
+      <width>21</width>
       <height>20</height>
      </rect>
     </property>
@@ -177,7 +175,7 @@
    <widget class="QLabel" name="live_image">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>127</x>
       <y>67</y>
       <width>320</width>
       <height>240</height>
@@ -205,7 +203,7 @@
    <widget class="QLabel" name="current_split_image">
     <property name="geometry">
      <rect>
-      <x>449</x>
+      <x>456</x>
       <y>67</y>
       <width>320</width>
       <height>240</height>
@@ -224,7 +222,7 @@
    <widget class="QLabel" name="current_image_label">
     <property name="geometry">
      <rect>
-      <x>449</x>
+      <x>456</x>
       <y>31</y>
       <width>318</width>
       <height>20</height>
@@ -241,8 +239,8 @@
     <property name="geometry">
      <rect>
       <x>11</x>
-      <y>183</y>
-      <width>44</width>
+      <y>190</y>
+      <width>49</width>
       <height>20</height>
      </rect>
     </property>
@@ -257,8 +255,8 @@
     <property name="geometry">
      <rect>
       <x>66</x>
-      <y>183</y>
-      <width>44</width>
+      <y>190</y>
+      <width>49</width>
       <height>20</height>
      </rect>
     </property>
@@ -273,7 +271,7 @@
     <property name="geometry">
      <rect>
       <x>65</x>
-      <y>254</y>
+      <y>272</y>
       <width>26</width>
       <height>20</height>
      </rect>
@@ -286,8 +284,8 @@
     <property name="geometry">
      <rect>
       <x>11</x>
-      <y>200</y>
-      <width>44</width>
+      <y>210</y>
+      <width>51</width>
       <height>24</height>
      </rect>
     </property>
@@ -308,8 +306,8 @@
     <property name="geometry">
      <rect>
       <x>66</x>
-      <y>200</y>
-      <width>44</width>
+      <y>210</y>
+      <width>51</width>
       <height>24</height>
      </rect>
     </property>
@@ -329,7 +327,7 @@
    <widget class="QLabel" name="capture_region_label">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>127</x>
       <y>31</y>
       <width>318</width>
       <height>20</height>
@@ -345,7 +343,7 @@
    <widget class="QLabel" name="current_image_file_label">
     <property name="geometry">
      <rect>
-      <x>477</x>
+      <x>484</x>
       <y>49</y>
       <width>264</width>
       <height>20</height>
@@ -362,9 +360,9 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>227</y>
-      <width>101</width>
-      <height>23</height>
+      <y>240</y>
+      <width>107</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -378,8 +376,8 @@
     <property name="geometry">
      <rect>
       <x>11</x>
-      <y>160</y>
-      <width>44</width>
+      <y>165</y>
+      <width>51</width>
       <height>24</height>
      </rect>
     </property>
@@ -406,8 +404,8 @@
     <property name="geometry">
      <rect>
       <x>66</x>
-      <y>160</y>
-      <width>44</width>
+      <y>165</y>
+      <width>51</width>
       <height>24</height>
      </rect>
     </property>
@@ -428,8 +426,8 @@
     <property name="geometry">
      <rect>
       <x>66</x>
-      <y>143</y>
-      <width>44</width>
+      <y>145</y>
+      <width>49</width>
       <height>20</height>
      </rect>
     </property>
@@ -445,8 +443,8 @@
      <rect>
       <x>10</x>
       <y>119</y>
-      <width>101</width>
-      <height>23</height>
+      <width>107</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -464,8 +462,8 @@
      <rect>
       <x>10</x>
       <y>93</y>
-      <width>101</width>
-      <height>23</height>
+      <width>107</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -480,7 +478,7 @@
      <rect>
       <x>696</x>
       <y>5</y>
-      <width>75</width>
+      <width>81</width>
       <height>24</height>
      </rect>
     </property>
@@ -496,7 +494,7 @@
      <rect>
       <x>10</x>
       <y>9</y>
-      <width>98</width>
+      <width>111</width>
       <height>16</height>
      </rect>
     </property>
@@ -507,9 +505,9 @@
    <widget class="QLineEdit" name="split_image_folder_input">
     <property name="geometry">
      <rect>
-      <x>119</x>
+      <x>127</x>
       <y>6</y>
-      <width>574</width>
+      <width>561</width>
       <height>22</height>
      </rect>
     </property>
@@ -520,7 +518,7 @@
    <widget class="QLabel" name="capture_region_window_label">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>127</x>
       <y>49</y>
       <width>318</width>
       <height>20</height>
@@ -536,9 +534,9 @@
    <widget class="QLabel" name="image_loop_label">
     <property name="geometry">
      <rect>
-      <x>451</x>
+      <x>458</x>
       <y>313</y>
-      <width>67</width>
+      <width>81</width>
       <height>20</height>
      </rect>
     </property>
@@ -549,7 +547,7 @@
    <widget class="QGroupBox" name="similarity_viewer_groupbox">
     <property name="geometry">
      <rect>
-      <x>120</x>
+      <x>127</x>
       <y>312</y>
       <width>321</width>
       <height>84</height>
@@ -800,9 +798,9 @@
    <widget class="QPushButton" name="reload_start_image_button">
     <property name="geometry">
      <rect>
-      <x>450</x>
+      <x>457</x>
       <y>369</y>
-      <width>121</width>
+      <width>131</width>
       <height>27</height>
      </rect>
     </property>
@@ -816,10 +814,10 @@
    <widget class="QLabel" name="start_image_status_label">
     <property name="geometry">
      <rect>
-      <x>449</x>
+      <x>458</x>
       <y>344</y>
-      <width>101</width>
-      <height>16</height>
+      <width>121</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
@@ -829,10 +827,10 @@
    <widget class="QLabel" name="start_image_status_value_label">
     <property name="geometry">
      <rect>
-      <x>560</x>
+      <x>577</x>
       <y>344</y>
-      <width>98</width>
-      <height>16</height>
+      <width>81</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="text">
@@ -842,9 +840,9 @@
    <widget class="QLabel" name="image_loop_value_label">
     <property name="geometry">
      <rect>
-      <x>520</x>
+      <x>537</x>
       <y>313</y>
-      <width>131</width>
+      <width>121</width>
       <height>20</height>
      </rect>
     </property>
@@ -858,7 +856,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>448</x>
+      <x>455</x>
       <y>49</y>
       <width>27</width>
       <height>18</height>
@@ -880,7 +878,7 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>743</x>
+      <x>750</x>
       <y>49</y>
       <width>27</width>
       <height>18</height>
@@ -938,7 +936,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>777</width>
+     <width>786</width>
      <height>22</height>
     </rect>
    </property>
@@ -974,6 +972,9 @@
    <property name="shortcut">
     <string>F1</string>
    </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_about">
    <property name="text">
@@ -990,6 +991,9 @@
    <property name="shortcut">
     <string>Ctrl+S</string>
    </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_load_profile">
    <property name="text">
@@ -998,6 +1002,9 @@
    <property name="shortcut">
     <string>Ctrl+O</string>
    </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
   </action>
   <action name="action_save_profile_as">
    <property name="text">
@@ -1005,6 +1012,9 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
    </property>
   </action>
   <action name="action_check_for_updates">
@@ -1018,6 +1028,9 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+,</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>

--- a/res/design.ui
+++ b/res/design.ui
@@ -972,9 +972,6 @@
    <property name="shortcut">
     <string>F1</string>
    </property>
-   <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
-   </property>
   </action>
   <action name="action_about">
    <property name="text">
@@ -991,9 +988,6 @@
    <property name="shortcut">
     <string>Ctrl+S</string>
    </property>
-   <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
-   </property>
   </action>
   <action name="action_load_profile">
    <property name="text">
@@ -1002,9 +996,6 @@
    <property name="shortcut">
     <string>Ctrl+O</string>
    </property>
-   <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
-   </property>
   </action>
   <action name="action_save_profile_as">
    <property name="text">
@@ -1012,9 +1003,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
-   </property>
-   <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
    </property>
   </action>
   <action name="action_check_for_updates">
@@ -1028,9 +1016,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+,</string>
-   </property>
-   <property name="shortcutContext">
-    <enum>Qt::ApplicationShortcut</enum>
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>

--- a/res/settings.ui
+++ b/res/settings.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>291</width>
-    <height>661</height>
+    <width>290</width>
+    <height>664</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>291</width>
-    <height>661</height>
+    <width>290</width>
+    <height>664</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>291</width>
-    <height>661</height>
+    <width>290</width>
+    <height>664</height>
    </size>
   </property>
   <property name="font">
@@ -32,16 +32,14 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>:/resources/icon.ico</normaloff>
-    :/resources/icon.ico
-   </iconset>
+    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
   </property>
   <widget class="QGroupBox" name="capture_settings_groupbox">
    <property name="geometry">
     <rect>
      <x>10</x>
      <y>200</y>
-     <width>271</width>
+     <width>270</width>
      <height>181</height>
     </rect>
    </property>
@@ -51,10 +49,10 @@
    <widget class="QSpinBox" name="fps_limit_spinbox">
     <property name="geometry">
      <rect>
-      <x>138</x>
-      <y>25</y>
+      <x>150</x>
+      <y>24</y>
       <width>51</width>
-      <height>22</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="correctionMode">
@@ -75,7 +73,7 @@
      <rect>
       <x>6</x>
       <y>27</y>
-      <width>121</width>
+      <width>141</width>
       <height>16</height>
      </rect>
     </property>
@@ -87,14 +85,11 @@
     </property>
    </widget>
    <widget class="QCheckBox" name="live_capture_region_checkbox">
-    <property name="enabled">
-     <bool>true</bool>
-    </property>
     <property name="geometry">
      <rect>
       <x>6</x>
       <y>49</y>
-      <width>129</width>
+      <width>141</width>
       <height>20</height>
      </rect>
     </property>
@@ -166,8 +161,8 @@
     <rect>
      <x>10</x>
      <y>390</y>
-     <width>271</width>
-     <height>261</height>
+     <width>270</width>
+     <height>266</height>
     </rect>
    </property>
    <property name="title">
@@ -185,9 +180,9 @@
    <widget class="QComboBox" name="default_comparison_method">
     <property name="geometry">
      <rect>
-      <x>167</x>
+      <x>170</x>
       <y>25</y>
-      <width>88</width>
+      <width>91</width>
       <height>22</height>
      </rect>
     </property>
@@ -202,8 +197,8 @@ Histograms:
 An explanation on Histograms comparison can be found here
 https://mpatacchiola.github.io/blog/2016/11/12/the-simplest-classifier-histogram-intersection.html
 This is a great method to use if you are using several masked images.
-> This algorithm is particular reliable when the colour is a strong predictor of the object identity.
-> The histogram intersection [...] is robust to occluding objects in the foreground.
+&gt; This algorithm is particular reliable when the colour is a strong predictor of the object identity.
+&gt; The histogram intersection [...] is robust to occluding objects in the foreground.
 
 Perceptual Hash:
 An explanation on pHash comparison can be found here
@@ -231,7 +226,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>28</y>
-      <width>161</width>
+      <width>171</width>
       <height>16</height>
      </rect>
     </property>
@@ -244,7 +239,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>118</y>
-      <width>161</width>
+      <width>171</width>
       <height>16</height>
      </rect>
     </property>
@@ -255,10 +250,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QDoubleSpinBox" name="default_pause_time_spinbox">
     <property name="geometry">
      <rect>
-      <x>167</x>
+      <x>170</x>
       <y>115</y>
-      <width>87</width>
-      <height>22</height>
+      <width>91</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="toolTip">
@@ -285,7 +280,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>58</y>
-      <width>151</width>
+      <width>171</width>
       <height>16</height>
      </rect>
     </property>
@@ -296,10 +291,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QDoubleSpinBox" name="default_similarity_threshold_spinbox">
     <property name="geometry">
      <rect>
-      <x>167</x>
+      <x>170</x>
       <y>55</y>
-      <width>52</width>
-      <height>22</height>
+      <width>51</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="toolTip">
@@ -319,14 +314,11 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     </property>
    </widget>
    <widget class="QCheckBox" name="loop_splits_checkbox">
-    <property name="enabled">
-     <bool>true</bool>
-    </property>
     <property name="geometry">
      <rect>
       <x>6</x>
       <y>143</y>
-      <width>235</width>
+      <width>261</width>
       <height>20</height>
      </rect>
     </property>
@@ -344,9 +336,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>6</x>
-      <y>190</y>
+      <y>193</y>
       <width>261</width>
-      <height>61</height>
+      <height>71</height>
      </rect>
     </property>
     <property name="font">
@@ -367,7 +359,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>88</y>
-      <width>161</width>
+      <width>171</width>
       <height>16</height>
      </rect>
     </property>
@@ -378,10 +370,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QSpinBox" name="default_delay_time_spinbox">
     <property name="geometry">
      <rect>
-      <x>167</x>
+      <x>170</x>
       <y>85</y>
-      <width>87</width>
-      <height>22</height>
+      <width>91</width>
+      <height>24</height>
      </rect>
     </property>
     <property name="toolTip">
@@ -398,13 +390,14 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>140</x>
-      <y>210</y>
+      <y>218</y>
       <width>71</width>
       <height>31</height>
      </rect>
     </property>
     <property name="font">
      <font>
+      <family>Segoe UI</family>
       <pointsize>8</pointsize>
       <bold>true</bold>
      </font>
@@ -427,7 +420,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <rect>
       <x>6</x>
       <y>168</y>
-      <width>151</width>
+      <width>171</width>
       <height>20</height>
      </rect>
     </property>
@@ -444,7 +437,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>271</width>
+     <width>270</width>
      <height>191</height>
     </rect>
    </property>
@@ -464,9 +457,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>130</y>
+      <y>128</y>
       <width>81</width>
-      <height>21</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -477,15 +470,12 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     </property>
    </widget>
    <widget class="QLineEdit" name="split_input">
-    <property name="enabled">
-     <bool>true</bool>
-    </property>
     <property name="geometry">
      <rect>
-      <x>76</x>
-      <y>30</y>
+      <x>80</x>
+      <y>25</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -498,10 +488,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QLineEdit" name="undo_split_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
-      <y>80</y>
+      <x>80</x>
+      <y>77</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -515,7 +505,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>6</x>
-      <y>32</y>
+      <y>28</y>
       <width>71</width>
       <height>16</height>
      </rect>
@@ -527,10 +517,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QLineEdit" name="reset_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
-      <y>55</y>
+      <x>80</x>
+      <y>51</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -544,9 +534,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>80</y>
+      <y>76</y>
       <width>81</width>
-      <height>21</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -560,7 +550,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>6</x>
-      <y>57</y>
+      <y>54</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -573,9 +563,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>55</y>
+      <y>50</y>
       <width>81</width>
-      <height>21</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -589,9 +579,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>30</y>
+      <y>24</y>
       <width>81</width>
-      <height>21</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -617,10 +607,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QLineEdit" name="pause_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
-      <y>130</y>
+      <x>80</x>
+      <y>129</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -634,7 +624,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>6</x>
-      <y>82</y>
+      <y>80</y>
       <width>71</width>
       <height>16</height>
      </rect>
@@ -647,9 +637,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>105</y>
+      <y>102</y>
       <width>81</width>
-      <height>21</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -663,7 +653,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>6</x>
-      <y>107</y>
+      <y>106</y>
       <width>61</width>
       <height>16</height>
      </rect>
@@ -675,10 +665,10 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
    <widget class="QLineEdit" name="skip_split_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
-      <y>105</y>
+      <x>80</x>
+      <y>103</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -692,9 +682,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>155</y>
+      <y>154</y>
       <width>81</width>
-      <height>21</height>
+      <height>24</height>
      </rect>
     </property>
     <property name="focusPolicy">
@@ -708,9 +698,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <property name="geometry">
      <rect>
       <x>6</x>
-      <y>154</y>
+      <y>151</y>
       <width>71</width>
-      <height>31</height>
+      <height>32</height>
      </rect>
     </property>
     <property name="text">
@@ -721,10 +711,10 @@ reset image</string>
    <widget class="QLineEdit" name="toggle_auto_reset_image_input">
     <property name="geometry">
      <rect>
-      <x>76</x>
+      <x>80</x>
       <y>155</y>
       <width>94</width>
-      <height>20</height>
+      <height>22</height>
      </rect>
     </property>
     <property name="text">
@@ -737,11 +727,11 @@ reset image</string>
   </widget>
  </widget>
  <tabstops>
-  <tabstop>split_input</tabstop>
-  <tabstop>reset_input</tabstop>
-  <tabstop>undo_split_input</tabstop>
-  <tabstop>skip_split_input</tabstop>
-  <tabstop>pause_input</tabstop>
+  <tabstop>set_split_hotkey_button</tabstop>
+  <tabstop>set_reset_hotkey_button</tabstop>
+  <tabstop>set_undo_split_hotkey_button</tabstop>
+  <tabstop>set_skip_split_hotkey_button</tabstop>
+  <tabstop>set_pause_hotkey_button</tabstop>
   <tabstop>fps_limit_spinbox</tabstop>
   <tabstop>live_capture_region_checkbox</tabstop>
   <tabstop>capture_method_combobox</tabstop>

--- a/res/update_checker.ui
+++ b/res/update_checker.ui
@@ -9,20 +9,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>313</width>
-    <height>133</height>
+    <width>318</width>
+    <height>132</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>313</width>
-    <height>133</height>
+    <width>318</width>
+    <height>132</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>313</width>
-    <height>133</height>
+    <width>318</width>
+    <height>132</height>
    </size>
   </property>
   <property name="font">
@@ -43,9 +43,9 @@
   <widget class="QLabel" name="update_status_label">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>10</y>
-     <width>218</width>
+     <width>251</width>
      <height>16</height>
     </rect>
    </property>
@@ -62,9 +62,9 @@
   <widget class="QLabel" name="current_version_label">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>30</y>
-     <width>91</width>
+     <width>101</width>
      <height>16</height>
     </rect>
    </property>
@@ -75,9 +75,9 @@
   <widget class="QLabel" name="latest_version_label">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>50</y>
-     <width>81</width>
+     <width>101</width>
      <height>16</height>
     </rect>
    </property>
@@ -88,9 +88,9 @@
   <widget class="QLabel" name="go_to_download_label">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>80</y>
-     <width>119</width>
+     <width>141</width>
      <height>16</height>
     </rect>
    </property>
@@ -101,9 +101,9 @@
   <widget class="QPushButton" name="left_button">
    <property name="geometry">
     <rect>
-     <x>150</x>
+     <x>160</x>
      <y>100</y>
-     <width>75</width>
+     <width>71</width>
      <height>24</height>
     </rect>
    </property>
@@ -117,9 +117,9 @@
   <widget class="QPushButton" name="right_button">
    <property name="geometry">
     <rect>
-     <x>230</x>
+     <x>240</x>
      <y>100</y>
-     <width>75</width>
+     <width>71</width>
      <height>24</height>
     </rect>
    </property>
@@ -130,9 +130,9 @@
   <widget class="QLabel" name="current_version_number_label">
    <property name="geometry">
     <rect>
-     <x>120</x>
+     <x>110</x>
      <y>30</y>
-     <width>181</width>
+     <width>191</width>
      <height>16</height>
     </rect>
    </property>
@@ -143,9 +143,9 @@
   <widget class="QLabel" name="latest_version_number_label">
    <property name="geometry">
     <rect>
-     <x>120</x>
+     <x>110</x>
      <y>50</y>
-     <width>181</width>
+     <width>191</width>
      <height>16</height>
     </rect>
    </property>
@@ -156,9 +156,9 @@
   <widget class="QCheckBox" name="do_not_ask_again_checkbox">
    <property name="geometry">
     <rect>
-     <x>20</x>
+     <x>10</x>
      <y>102</y>
-     <width>131</width>
+     <width>151</width>
      <height>20</height>
     </rect>
    </property>

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -27,7 +27,7 @@ unify
 #
 # Run `./scripts/designer.ps1` to quickly open the bundled PyQt Designer.
 # Can also be downloaded externally as a non-python package
-qt6-applications
+# qt6-applications
 # Types
 types-d3dshot
 types-keyboard


### PR DESCRIPTION
- Main and settings window are slightly wider
- Shifted everything to the right in the main window to give more place to the left column
- Re-aligned elements in the left column
- All windows have an even pixel size
- All buttons are at least 24px high
- Increase spacing between horizontal label elements to account for weird DPI issues on some machines
- Max FPS button has been made larger so the text doesn't cut off
- X, Y, Width and Height combo boxes have all been made larger to fit 4 numbers
- Re-aligned hotkeys elements
- Give more height to multiline labels
- Align the logo in the about page to the right
- Update checker text is all shifted to the left
- Remove extra leftover `btn_donateCC_LG` pixmap in about (we use html to render the image with a link)
- tabstop on the hotkey buttons, not the input fields

Designer view:
![image](https://user-images.githubusercontent.com/1350584/233792189-8b743b92-3168-4531-bc4d-56890baec402.png)

Sanity check on Windows 10:
![image](https://user-images.githubusercontent.com/1350584/233792200-6d3c054d-2bf7-43dc-9bd1-26d9760b0142.png)