### PR TITLE
Fix new possible BitBlt error when closing a window

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,10 @@ The AutoSplit LiveSplit Component will directly connect AutoSplit with LiveSplit
 ## Resources
 
 Still need help?
-
-- [Check if your issue already exists or open a new one](../../issues)
+<!-- open issues sorted by reactions -->
+- [Check if your issue already exists](../../issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)
+  - If it does, upvote it 👍
+  - If it doesn't, create a new one
 - Join the [AutoSplit Discord  
 ![AutoSplit Discord](https://badgen.net/discord/members/Qcbxv9y)](https://discord.gg/Qcbxv9y)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,6 +11,7 @@ from threading import Thread
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import cv2
+import win32ui
 from win32 import win32gui
 from winsdk.windows.ai.machinelearning import LearningModelDevice, LearningModelDeviceKind
 from winsdk.windows.media.capture import MediaCapture
@@ -18,6 +19,8 @@ from winsdk.windows.media.capture import MediaCapture
 from gen.build_vars import AUTOSPLIT_BUILD_NUMBER, AUTOSPLIT_GITHUB_REPOSITORY
 
 if TYPE_CHECKING:
+    # Source does not exist, keep this under TYPE_CHECKING
+    from _win32typing import PyCDC  # pyright: ignore[reportMissingModuleSource]
     from typing_extensions import ParamSpec, TypeGuard
     P = ParamSpec("P")
 
@@ -62,6 +65,13 @@ T = TypeVar("T")
 def first(iterable: Iterable[T]) -> T:
     """@return: The first element of a collection. Dictionaries will return the first key"""
     return next(iter(iterable))
+
+
+def try_delete_dc(dc: PyCDC):
+    try:
+        dc.DeleteDC()
+    except win32ui.error:
+        pass
 
 
 def get_window_bounds(hwnd: int) -> tuple[int, int, int, int]:


### PR DESCRIPTION
This can be semi-consistently repeated for me by recording Dolphin, closing the game window, but not the emulator itself. Happens about half of the time.

Let's just silently pass if a `PyCDC` can't be deleted. It's meant to be cleanup code, it's fine if the thing doesn't exist.