### PR TITLE
Fix region auto align.

### DIFF
--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -235,12 +235,10 @@ def __test_alignment(capture: cv2.Mat, template: cv2.Mat):  # pylint: disable=to
     best_width = 0
     best_loc = (0, 0)
 
-    # If the number of color channels don't match, we can run cv2.matchTemplate()
-    if capture.shape[2] != template.shape[2]:
-        if capture.shape[2] == 4:
-            capture = capture[:, :, :3]
-        if template.shape[2] == 4:
-            template = template[:, :, :3]
+    # Add alpha channel to template if it's missing. The cv2.matchTemplate() function
+    # needs both images to have the same color dimensions, and capture has an alpha channel
+    if template.shape[2] == 3:
+        template = cv2.cvtColor(template, cv2.COLOR_BGR2BGRA)
 
     # This tests 50 images scaled from 20% to 300% of the original template size
     for scale in np.linspace(0.2, 3, num=56):

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -234,7 +234,14 @@ def __test_alignment(capture: cv2.Mat, template: cv2.Mat):  # pylint: disable=to
     best_height = 0
     best_width = 0
     best_loc = (0, 0)
-
+    
+    # Strip excess color channels if they are present
+    if capture.shape[2] != template.shape[2]:
+        if capture.shape[2] == 4:
+            capture = capture[:, :, :3]
+        if template.shape[2] == 4:
+            template = template[:, :, :3]
+    
     # This tests 50 images scaled from 20% to 300% of the original template size
     for scale in np.linspace(0.2, 3, num=56):
         width = int(template.shape[1] * scale)

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -234,14 +234,14 @@ def __test_alignment(capture: cv2.Mat, template: cv2.Mat):  # pylint: disable=to
     best_height = 0
     best_width = 0
     best_loc = (0, 0)
-    
-    # Strip excess color channels if they are present
+
+    # If the number of color channels don't match, we can run cv2.matchTemplate()
     if capture.shape[2] != template.shape[2]:
         if capture.shape[2] == 4:
             capture = capture[:, :, :3]
         if template.shape[2] == 4:
             template = template[:, :, :3]
-    
+
     # This tests 50 images scaled from 20% to 300% of the original template size
     for scale in np.linspace(0.2, 3, num=56):
         width = int(template.shape[1] * scale)


### PR DESCRIPTION
I noticed that the two images (capture and template) can have different number of color channels. If that's the case, the matchTemplate function will throw an exception. By stripping excess channels, should they be present, we fix the issue.

My Python knowledge is pretty limited though so I am not sure if I modify the underlying data structure here, or create a copy, so I'd love feedback on that.

Fixes #231 