### PR TITLE
Option for start command to also reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ If this option is enabled, when the last split meets the threshold and splits, A
 If this option is disabled, when the last split meets the threshold and splits, AutoSplit will stop running comparisons.
 This option does not loop single, specific images. See the Custom Split Image Settings section above for this feature.
 
+#### Start also Resets
+
+If this option is enabled, a "Start" command (ie: from the Start Image) will also send the "Reset" command. This is useful if you want to automatically restart your timer using the Start Image. Since AutoSplit won't be running and won't be checking for the Reset Image.
+
+Having the reset image check be active at all time would be a better, more organic solution in the future. But that is dependent on migrating to an observer pattern (<https://github.com/Toufool/AutoSplit/issues/219>) and being able to reload all images.
+
 #### Enable auto Reset Image
 
 This option is mainly meant to be toggled with the `Toggle auto Reset Image` hotkey. You can enable it to temporarily disable the Reset Image if you make a mistake in your run that would cause the Reset Image to trigger. Like exiting back to the game's menu (aka Save&Quit).

--- a/res/settings.ui
+++ b/res/settings.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>285</width>
-    <height>274</height>
+    <height>294</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -20,7 +20,7 @@
   <property name="maximumSize">
    <size>
     <width>310</width>
-    <height>290</height>
+    <height>294</height>
    </size>
   </property>
   <property name="font">
@@ -41,7 +41,7 @@
      <x>-3</x>
      <y>-3</y>
      <width>291</width>
-     <height>281</height>
+     <height>301</height>
     </rect>
    </property>
    <property name="currentIndex">
@@ -551,7 +551,7 @@ reset image</string>
      <property name="geometry">
       <rect>
        <x>144</x>
-       <y>205</y>
+       <y>220</y>
        <width>71</width>
        <height>31</height>
       </rect>
@@ -599,7 +599,7 @@ reset image</string>
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>153</y>
+       <y>170</y>
        <width>261</width>
        <height>24</height>
       </rect>
@@ -691,9 +691,9 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>180</y>
+       <y>200</y>
        <width>261</width>
-       <height>71</height>
+       <height>61</height>
       </rect>
      </property>
      <property name="font">
@@ -801,6 +801,25 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
       <string>Default Delay Time (ms):</string>
      </property>
     </widget>
+    <widget class="QCheckBox" name="start_also_resets_checkbox">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>150</y>
+       <width>261</width>
+       <height>24</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Start also Resets</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <property name="tristate">
+      <bool>false</bool>
+     </property>
+    </widget>
     <zorder>custom_image_settings_info_label</zorder>
     <zorder>default_delay_time_spinbox</zorder>
     <zorder>enable_auto_reset_image_checkbox</zorder>
@@ -813,6 +832,7 @@ It is highly recommended to NOT use pHash if you use masked images, or it'll be 
     <zorder>default_pause_time_label</zorder>
     <zorder>default_delay_time_label</zorder>
     <zorder>readme_link_button</zorder>
+    <zorder>start_also_resets_checkbox</zorder>
    </widget>
   </widget>
  </widget>

--- a/src/hotkeys.py
+++ b/src/hotkeys.py
@@ -50,9 +50,18 @@ def after_setting_hotkey(autosplit: AutoSplit):
 
 
 def send_command(autosplit: AutoSplit, command: Commands):
+    # Note: Rather than having the start image able to also reset the timer,
+    # having the reset image check be active at all time would be a better, more organic solution,
+    # but that is dependent on migrating to an observer pattern (#219) and being able to reload all images.
     if autosplit.is_auto_controlled:
+        if command == "start" and autosplit.settings_dict["start_also_resets"]:
+            print("reset", flush=True)
         print(command, flush=True)
-    elif command in {"split", "start"}:
+    elif command == "start":
+        if autosplit.settings_dict["start_also_resets"]:
+            _send_hotkey(autosplit.settings_dict["reset_hotkey"])
+        _send_hotkey(autosplit.settings_dict["split_hotkey"])
+    elif command == "split":
         _send_hotkey(autosplit.settings_dict["split_hotkey"])
     elif command == "pause":
         _send_hotkey(autosplit.settings_dict["pause_hotkey"])
@@ -64,7 +73,7 @@ def send_command(autosplit: AutoSplit, command: Commands):
         _send_hotkey(autosplit.settings_dict["undo_split_hotkey"])
 
     else:
-        raise KeyError(f"{command!r} is not a valid LiveSplit.AutoSplitIntegration command")
+        raise KeyError(f"{command!r} is not a valid command")
 
 
 def _unhook(hotkey_callback: Callable[[], None] | None):

--- a/src/menu_bar.py
+++ b/src/menu_bar.py
@@ -315,6 +315,7 @@ class __SettingsWidget(QtWidgets.QWidget, settings_ui.Ui_SettingsWidget):  # noq
         self.default_delay_time_spinbox.setValue(self.autosplit.settings_dict["default_delay_time"])
         self.default_pause_time_spinbox.setValue(self.autosplit.settings_dict["default_pause_time"])
         self.loop_splits_checkbox.setChecked(self.autosplit.settings_dict["loop_splits"])
+        self.start_also_resets_checkbox.setChecked(self.autosplit.settings_dict["start_also_resets"])
         self.enable_auto_reset_image_checkbox.setChecked(self.autosplit.settings_dict["enable_auto_reset"])
 # endregion
 # region Binding
@@ -350,6 +351,9 @@ class __SettingsWidget(QtWidgets.QWidget, settings_ui.Ui_SettingsWidget):  # noq
         self.loop_splits_checkbox.stateChanged.connect(
             lambda: self.__set_value("loop_splits", self.loop_splits_checkbox.isChecked()),
         )
+        self.start_also_resets_checkbox.stateChanged.connect(
+            lambda: self.__set_value("start_also_resets", self.start_also_resets_checkbox.isChecked()),
+        )
         self.enable_auto_reset_image_checkbox.stateChanged.connect(
             lambda: self.__set_value("enable_auto_reset", self.enable_auto_reset_image_checkbox.isChecked()),
         )
@@ -375,7 +379,6 @@ def get_default_settings_from_ui(autosplit: AutoSplit):
         "toggle_auto_reset_image_hotkey": default_settings_dialog.toggle_auto_reset_image_input.text(),
         "fps_limit": default_settings_dialog.fps_limit_spinbox.value(),
         "live_capture_region": default_settings_dialog.live_capture_region_checkbox.isChecked(),
-        "enable_auto_reset": default_settings_dialog.enable_auto_reset_image_checkbox.isChecked(),
         "capture_method": CAPTURE_METHODS.get_method_by_index(
             default_settings_dialog.capture_method_combobox.currentIndex(),
         ),
@@ -386,6 +389,8 @@ def get_default_settings_from_ui(autosplit: AutoSplit):
         "default_delay_time": default_settings_dialog.default_delay_time_spinbox.value(),
         "default_pause_time": default_settings_dialog.default_pause_time_spinbox.value(),
         "loop_splits": default_settings_dialog.loop_splits_checkbox.isChecked(),
+        "start_also_resets": default_settings_dialog.start_also_resets_checkbox.isChecked(),
+        "enable_auto_reset": default_settings_dialog.enable_auto_reset_image_checkbox.isChecked(),
         "split_image_directory": autosplit.split_image_folder_input.text(),
         "screenshot_directory": default_settings_dialog.screenshot_directory_input.text(),
         "open_screenshot": default_settings_dialog.open_screenshot_checkbox.isChecked(),

--- a/src/user_profile.py
+++ b/src/user_profile.py
@@ -26,7 +26,6 @@ class UserProfileDict(TypedDict):
     toggle_auto_reset_image_hotkey: str
     fps_limit: int
     live_capture_region: bool
-    enable_auto_reset: bool
     capture_method: str | CaptureMethodEnum
     capture_device_id: int
     capture_device_name: str
@@ -35,6 +34,8 @@ class UserProfileDict(TypedDict):
     default_delay_time: int
     default_pause_time: float
     loop_splits: bool
+    start_also_resets: bool
+    enable_auto_reset: bool
     split_image_directory: str
     screenshot_directory: str
     open_screenshot: bool
@@ -52,7 +53,6 @@ DEFAULT_PROFILE = UserProfileDict(
     toggle_auto_reset_image_hotkey="",
     fps_limit=60,
     live_capture_region=True,
-    enable_auto_reset=True,
     capture_method=CAPTURE_METHODS.get_method_by_index(0),
     capture_device_id=0,
     capture_device_name="",
@@ -61,6 +61,8 @@ DEFAULT_PROFILE = UserProfileDict(
     default_delay_time=0,
     default_pause_time=10,
     loop_splits=False,
+    start_also_resets=False,
+    enable_auto_reset=True,
     split_image_directory="",
     screenshot_directory="",
     open_screenshot=True,


### PR DESCRIPTION
## What problem does this solve?

See how Torje here cannot automatically reset their timer whilst AutoSplit isn't running: https://youtu.be/Tt0llYwGFgw

After carefully looking at it, it seems everything is working as intended in AutoSplit:
- Whilst AutoSplit is running, the reset image is checked. And that's why resetting works mid-run.
- The reset image isn't checked whilst AutoSplit is not running.
- The reset image is not checked during the start image's "pause time". That's also on purpose otherwise you'd be stuck in a loop.

On LiveSplit's side:
- The timer will only reset from a "reset" or "split" command.
- With hotkeys, start/split is the same thing
- With its API, a "start" command specifically won't start the timer when the run is ended. Which is what's happening to you.
- A "start" command also won't split (but that's irrelevant here)

Doc: https://github.com/LiveSplit/LiveSplit.AutoSplitters/blob/master/README.md#automatic-timer-start-1
> Note that the start action will only be run if the timer is currently not running.

And confirmed by looking at the source https://github.com/LiveSplit/LiveSplit/blob/4d30d15ec62e3bb24910b0944949fb55265f3884/LiveSplit/LiveSplit.Core/Model/TimerModel.cs#L37-L53

## Potential solutions

So it seems that what we need is either:
- Have the reset image still be checked whilst AutoSplit is not running. This may require changing when AutoSplit pre-loads and parses images. Like changing the "reload star image" button with "reload all images". And once AutoSplit uses an observer pattern instead of a synchronous loop.
- Have the start image also emit the reset command/hotkey. I'm not immediately certain if this should always be the case, so I'd make it an option. That'd be doable quickly short term.

Here I'm going for the second solution which is immediately actionable, and making it an option as it may not always be desirable. The first solution would be better long term but is dependant on #219