### PR TITLE
Re-implement `pHash` comparison using `cv2`. Drop `imagehash`+`Pillow`

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -17,7 +17,7 @@ $arguments = @(
   '--exclude=pymsgbox',
   '--exclude=pytweening',
   '--exclude=mouseinfo',
-  # Used by imagehash.whash
-  '--exclude=pywt')
+  # Used by D3DShot
+  '--exclude=PIL')
 
 Start-Process -Wait -NoNewWindow pyinstaller -ArgumentList $arguments

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -6,9 +6,9 @@ pip install -r "$PSScriptRoot/requirements$dev.txt" --upgrade
 # These libraries install extra requirements we don't want
 # Open suggestion for support in requirements files: https://github.com/pypa/pip/issues/9948 & https://github.com/pypa/pip/pull/10837
 # PyAutoGUI: We only use it for hotkeys
-# ImageHash: uneeded + broken on Python 3.12 PyWavelets install
-# scipy: needed for ImageHash
-pip install PyAutoGUI ImageHash scipy --no-deps --upgrade
+# D3DShot: Will install Pillow, which we don't use on Windows.
+#          Even then, PyPI with Pillow>=7.2.0 will install 0.1.3 instead of 0.1.5
+pip install PyAutoGUI "D3DShot>=0.1.5 ; sys_platform == 'win32'" --no-deps --upgrade
 
 # Patch libraries so we don't have to install from git
 
@@ -24,11 +24,11 @@ $libPath = python -c 'import pymonctl as _; print(_.__path__[0])'
 $libPath = python -c 'import pywinbox as _; print(_.__path__[0])'
 (Get-Content "$libPath/_pywinbox_win.py").replace('ctypes.windll.shcore.SetProcessDpiAwareness(2)', 'pass') |
   Set-Content "$libPath/_pywinbox_win.py"
-# Uninstall optional dependencies if PyAutoGUI was installed outside this script
+# Uninstall optional dependencies if PyAutoGUI or D3DShot was installed outside this script
 # pyscreeze -> pyscreenshot -> mss deps call SetProcessDpiAwareness
-# pygetwindow, pymsgbox, pytweening, MouseInfo are picked up by PySide6
+# Pillow, pygetwindow, pymsgbox, pytweening, MouseInfo are picked up by PySide6
 # (also --exclude from build script, but more consistent with unfrozen run)
-python -m pip uninstall pyscreeze pyscreenshot mss pygetwindow pymsgbox pytweening MouseInfo -y
+python -m pip uninstall pyscreeze pyscreenshot mss Pillow pygetwindow pymsgbox pytweening MouseInfo -y
 
 
 # Don't compile resources on the Build CI job as it'll do so in build script

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -19,7 +19,6 @@ ruff>=0.1.7 # New checks # Must match .pre-commit-config.yaml
 # Types
 types-D3DShot ; sys_platform == 'win32'
 types-keyboard
-types-Pillow
 types-psutil
 types-PyAutoGUI
 types-pyinstaller

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,18 +4,17 @@
 #
 # Dependencies:
 certifi
-ImageHash>=4.3.1 ; python_version < '3.12' # Contains type information + setup as package not module  # PyWavelets install broken on Python 3.12
 git+https://github.com/boppreh/keyboard.git#egg=keyboard  # Fix install on macos and linux-ci https://github.com/boppreh/keyboard/pull/568
 numpy>=1.26  # Python 3.12 support
 opencv-python-headless>=4.8.1.78  # Typing fixes
 packaging
-Pillow>=10.0  # Python 3.12 support
 psutil>=5.9.6  # Python 3.12 fixes
-PyAutoGUI
+# PyAutoGUI # See install.ps1
 PyWinCtl>=0.0.42  # py.typed
 # When needed, dev builds can be found at https://download.qt.io/snapshots/ci/pyside/dev?C=M;O=D
 PySide6-Essentials>=6.6.0  # Python 3.12 support
 requests>=2.28.2  # charset_normalizer 3.x update
+scipy>=1.11.2 # Python 3.12 support
 toml
 typing-extensions>=4.4.0  # @override decorator support
 #
@@ -29,4 +28,4 @@ pyinstaller-hooks-contrib>=2022.15  # charset-normalizer fix https://github.com/
 pygrabber>=0.2 ; sys_platform == 'win32'  # Completed types
 pywin32>=301 ; sys_platform == 'win32'
 winsdk>=1.0.0b10 ; sys_platform == 'win32'  # Python 3.12 support
-git+https://github.com/ranchen421/D3DShot.git#egg=D3DShot ; sys_platform == 'win32'  # D3DShot from PyPI with Pillow>=7.2.0 will install 0.1.3 instead of 0.1.5
+# D3DShot # See install.ps1

--- a/src/compare.py
+++ b/src/compare.py
@@ -1,11 +1,9 @@
 from math import sqrt
-from typing import cast
 
 import cv2
 import numpy as np
-import numpy._typing as npt
-import scipy.fft
 from cv2.typing import MatLike
+from scipy import fft
 
 from utils import BGRA_CHANNEL_COUNT, MAXBYTE, ColorChannel, ImageShape, is_valid_image
 
@@ -98,7 +96,7 @@ def __cv2_phash(image: MatLike, hash_size: int = 8, highfreq_factor: int = 4):
     img_size = hash_size * highfreq_factor
     image = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
     image = cv2.resize(image, (img_size, img_size), interpolation=cv2.INTER_AREA)
-    dct = cast(npt.NDArray[np.float64], scipy.fft.dct(scipy.fft.dct(image, axis=0), axis=1))
+    dct = fft.dct(fft.dct(image, axis=0), axis=1)
     dct_low_frequency = dct[:hash_size, :hash_size]
     median = np.median(dct_low_frequency)
     return dct_low_frequency > median

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -79,7 +79,7 @@ def __select_graphics_item(autosplit: "AutoSplit"):  # pyright: ignore [reportUn
         autosplit.capture_method.reinitialize()
 
     picker = GraphicsCapturePicker()
-    initialize_with_window(picker, int(autosplit.effectiveWinId()))
+    initialize_with_window(picker, autosplit.effectiveWinId())
     async_operation = picker.pick_single_item_async()
     # None if the selection is canceled
     if async_operation:

--- a/typings/scipy/__init__.pyi
+++ b/typings/scipy/__init__.pyi
@@ -1,0 +1,55 @@
+
+from numpy.fft import ifft as ifft
+from numpy.random import rand as rand, randn as randn
+from scipy import (
+    cluster,
+    constants,
+    datasets,
+    fft,
+    fftpack,
+    integrate,
+    interpolate,
+    io,
+    linalg,
+    misc,
+    ndimage,
+    odr,
+    optimize,
+    signal,
+    sparse,
+    spatial,
+    special,
+    stats,
+)
+from scipy.__config__ import show as show_config
+from scipy._lib._ccallback import LowLevelCallable
+from scipy._lib._testutils import PytestTester
+from scipy.version import version as __version__
+
+__all__ = [
+    "cluster",
+    "constants",
+    "datasets",
+    "fft",
+    "fftpack",
+    "integrate",
+    "interpolate",
+    "io",
+    "linalg",
+    "misc",
+    "ndimage",
+    "odr",
+    "optimize",
+    "signal",
+    "sparse",
+    "spatial",
+    "special",
+    "stats",
+    "LowLevelCallable",
+    "test",
+    "show_config",
+    "__version__",
+]
+
+test: PytestTester
+def __dir__() -> list[str]: ...

--- a/typings/scipy/fft/__init__.pyi
+++ b/typings/scipy/fft/__init__.pyi
@@ -1,0 +1,72 @@
+from numpy.fft import fftfreq, fftshift, ifftshift, rfftfreq
+from scipy._lib._testutils import PytestTester
+from scipy.fft._backend import register_backend, set_backend, set_global_backend, skip_backend
+from scipy.fft._basic import (
+    fft,
+    fft2,
+    fftn,
+    hfft,
+    hfft2,
+    hfftn,
+    ifft,
+    ifft2,
+    ifftn,
+    ihfft,
+    ihfft2,
+    ihfftn,
+    irfft,
+    irfft2,
+    irfftn,
+    rfft,
+    rfft2,
+    rfftn,
+)
+from scipy.fft._fftlog import fhtoffset
+from scipy.fft._fftlog_multimethods import fht, ifht
+from scipy.fft._helper import next_fast_len
+from scipy.fft._pocketfft.helper import get_workers, set_workers
+from scipy.fft._realtransforms import dct, dctn, dst, dstn, idct, idctn, idst, idstn
+
+__all__ = [
+    "fft",
+    "ifft",
+    "fft2",
+    "ifft2",
+    "fftn",
+    "ifftn",
+    "rfft",
+    "irfft",
+    "rfft2",
+    "irfft2",
+    "rfftn",
+    "irfftn",
+    "hfft",
+    "ihfft",
+    "hfft2",
+    "ihfft2",
+    "hfftn",
+    "ihfftn",
+    "fftfreq",
+    "rfftfreq",
+    "fftshift",
+    "ifftshift",
+    "next_fast_len",
+    "dct",
+    "idct",
+    "dst",
+    "idst",
+    "dctn",
+    "idctn",
+    "dstn",
+    "idstn",
+    "fht",
+    "ifht",
+    "fhtoffset",
+    "set_backend",
+    "skip_backend",
+    "set_global_backend",
+    "register_backend",
+    "get_workers",
+    "set_workers",
+]
+test: PytestTester

--- a/typings/scipy/fft/_realtransforms.pyi
+++ b/typings/scipy/fft/_realtransforms.pyi
@@ -1,0 +1,102 @@
+from _typeshed import Incomplete
+from numpy import float64, generic
+from numpy.typing import NDArray
+
+__all__ = ["dct", "idct", "dst", "idst", "dctn", "idctn", "dstn", "idstn"]
+
+
+def dctn(
+    x,
+    type=2,
+    s=None,
+    axes=None,
+    norm=None,
+    overwrite_x=False,
+    workers=None,
+    *,
+    orthogonalize=None,
+): ...
+
+
+def idctn(
+    x,
+    type=2,
+    s=None,
+    axes=None,
+    norm=None,
+    overwrite_x=False,
+    workers=None,
+    orthogonalize=None,
+): ...
+
+
+def dstn(
+    x,
+    type=2,
+    s=None,
+    axes=None,
+    norm=None,
+    overwrite_x=False,
+    workers=None,
+    orthogonalize=None,
+): ...
+
+
+def idstn(
+    x,
+    type=2,
+    s=None,
+    axes=None,
+    norm=None,
+    overwrite_x=False,
+    workers=None,
+    orthogonalize=None,
+): ...
+
+
+def dct(
+    x: NDArray[generic],
+    type: int = 2,
+    n: Incomplete | None = None,
+    axis: int = -1,
+    norm: Incomplete | None = None,
+    overwrite_x: bool = False,
+    workers: Incomplete | None = None,
+    orthogonalize: Incomplete | None = None,
+) -> NDArray[float64]: ...
+
+
+def idct(
+    x,
+    type=2,
+    n=None,
+    axis=-1,
+    norm=None,
+    overwrite_x=False,
+    workers=None,
+    orthogonalize=None,
+): ...
+
+
+def dst(
+    x,
+    type=2,
+    n=None,
+    axis=-1,
+    norm=None,
+    overwrite_x=False,
+    workers=None,
+    orthogonalize=None,
+): ...
+
+
+def idst(
+    x,
+    type=2,
+    n=None,
+    axis=-1,
+    norm=None,
+    overwrite_x=False,
+    workers=None,
+    orthogonalize=None,
+): ...

--- a/typings/scipy/py.typed
+++ b/typings/scipy/py.typed
@@ -1,0 +1,1 @@
+partial


### PR DESCRIPTION
- Re-implement `pHash` comparison using `cv2`.
- Drop `imagehash` and `Pillow` as dependencies
- Reduce bundle size by 1.93MB (139.004 --> 137.074)
- ~1.6x speed improvement for pHash comparison
- Reduce install/build time considerably by not installing D3DShot from GitHub
- Testing suggests some images might differ in comparison from old implementation by at most 2/64 (3.125%)

Timing difference done using:
```python
    def new():
        source_hash = __cv2_phash(source)
        capture_hash = __cv2_phash(capture)
        return np.count_nonzero(source_hash != capture_hash)
    new_time = timeit.Timer(new).timeit(1000)

    def old():
        source_hash = imagehash.phash(Image.fromarray(source))
        capture_hash = imagehash.phash(Image.fromarray(capture))
        return source_hash - capture_hash
    old_time = timeit.Timer(old).timeit(1000)

    print(old_time, "/", new_time, "=", old_time / new_time)
```