### PR TITLE
Remove dependency on requests

### DIFF
--- a/PyInstaller/hooks/hook-requests.py
+++ b/PyInstaller/hooks/hook-requests.py
@@ -1,4 +1,0 @@
-from PyInstaller.utils.hooks import collect_data_files
-
-# Get the cacert.pem
-datas = collect_data_files("certifi")

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -24,5 +24,4 @@ types-psutil
 types-PyAutoGUI
 types-pyinstaller
 types-pywin32 ; sys_platform == 'win32'
-types-requests
 types-toml

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,7 +3,6 @@
 # Read /docs/build%20instructions.md for more information on how to install, run and build the python code.
 #
 # Dependencies:
-certifi
 ImageHash>=4.3.1 ; python_version < '3.12' # Contains type information + setup as package not module  # PyWavelets install broken on Python 3.12
 git+https://github.com/boppreh/keyboard.git#egg=keyboard  # Fix install on macos and linux-ci https://github.com/boppreh/keyboard/pull/568
 numpy>=1.26  # Python 3.12 support
@@ -15,13 +14,11 @@ PyAutoGUI
 PyWinCtl>=0.0.42  # py.typed
 # When needed, dev builds can be found at https://download.qt.io/snapshots/ci/pyside/dev?C=M;O=D
 PySide6-Essentials>=6.6.0  # Python 3.12 support
-requests>=2.28.2  # charset_normalizer 3.x update
 toml
 typing-extensions>=4.4.0  # @override decorator support
 #
 # Build and compile resources
 pyinstaller>=5.13  # Python 3.12 support
-pyinstaller-hooks-contrib>=2022.15  # charset-normalizer fix https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/534
 #
 # https://peps.python.org/pep-0508/#environment-markers
 #

--- a/src/AutoSplit.py
+++ b/src/AutoSplit.py
@@ -9,7 +9,6 @@ from time import time
 from types import FunctionType
 from typing import NoReturn
 
-import certifi
 import cv2
 from cv2.typing import MatLike
 from psutil import process_iter
@@ -52,8 +51,6 @@ from utils import (
 
 CHECK_FPS_ITERATIONS = 10
 
-# Needed when compiled, along with the custom hook-requests PyInstaller hook
-os.environ["REQUESTS_CA_BUNDLE"] = certifi.where()
 myappid = f"Toufool.AutoSplit.v{AUTOSPLIT_VERSION}"
 ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 


### PR DESCRIPTION
- Remove dependency on `requests`, and its sub-dependencies `certifi`, `charset-normalizer`, `idna` and `urllib3`
- Remove co-dependnecy specifications `certifi` and `pyinstaller-hooks-contrib`
- Remove custom pyinstaller hook
- Improves build time with reduced hooks
- Improve uncached install time slightly due to less dependencies
- Reduce executable size by 0.58MB (139.045 --> 138.459)
