### PR TITLE
interpolation=cv2.INTER_NEAREST in compare_with_capture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ max-branches = 15
 it doesn't support special characters. Use `utils.imread` instead.
 https://github.com/opencv/opencv/issues/4292#issuecomment-2266019697"""
 "cv2.imwrite".msg = """\
-it doesn't support special characters. . Use `utils.imwrite` instead.
+it doesn't support special characters. Use `utils.imwrite` instead.
 https://github.com/opencv/opencv/issues/4292#issuecomment-2266019697"""
 
 # https://github.com/hhatto/autopep8#usage

--- a/src/AutoSplitImage.py
+++ b/src/AutoSplitImage.py
@@ -202,7 +202,7 @@ class AutoSplitImage:
 
         if not is_valid_image(self.byte_array):
             return 0.0
-        resized_capture = cv2.resize(capture, self.byte_array.shape[1::-1])
+        resized_capture = cv2.resize(capture, self.byte_array.shape[1::-1], interpolation=cv2.INTER_NEAREST)
 
         return get_comparison_method_by_index(
             self.__get_comparison_method_index(default),


### PR DESCRIPTION
Spotted by @Faschz on Discord. This should probably not use the default linear interpolation to be consistant with other image resizing. Needs to be tested before merging.
(note that phash is purposefully using a different interpolation for backwards compatibility and it's an additional resizing on top anyway)