### PR TITLE
Migrate from winsdk to PyWinRT and bump tomli-w

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Not a developer? You can still help through the following methods:
   - <https://github.com/opencv/opencv/issues?q=is%3Aissue+is%3Aopen+involves%3AAvasam+sort%3Areactions-%2B1-asc+>
   - <https://github.com/opencv/opencv/issues/18305>
   - <https://github.com/opencv/opencv/issues/23906>
-  - <https://github.com/pywinrt/python-winsdk/issues/11>
+  - <https://github.com/pywinrt/pywinrt/issues/78>
   - <https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/807>
   - <https://github.com/hukkin/tomli-w/pull/46>
   - <https://github.com/uiri/toml/issues/270>

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -15,7 +15,7 @@ PyWinCtl>=0.0.42  # py.typed
 # When needed, dev builds can be found at https://download.qt.io/snapshots/ci/pyside/dev?C=M;O=D
 PySide6-Essentials>=6.6.0 # Python 3.12 support
 scipy>=1.11.2 # Python 3.12 support
-tomli-w
+tomli-w>=1.1.0  # Typing fixes
 typing-extensions>=4.4.0  # @override decorator support
 #
 # Build and compile resources

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -27,7 +27,15 @@ pyinstaller>=5.13  # Python 3.12 support
 comtypes<1.4.5 ; sys_platform == 'win32'  # https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/807
 pygrabber>=0.2 ; sys_platform == 'win32'  # Completed types
 pywin32>=301 ; sys_platform == 'win32'
-winsdk>=1.0.0b10 ; sys_platform == 'win32'  # Python 3.12 support
+winrt-Windows.AI.MachineLearning>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
+winrt-Windows.Foundation>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
+winrt-Windows.Graphics.Capture>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
+winrt-Windows.Graphics.Capture.Interop>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
+winrt-Windows.Graphics.DirectX>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
+winrt-Windows.Graphics.DirectX.Direct3D11>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
+winrt-Windows.Graphics.Imaging>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
+winrt-Windows.Graphics>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
+winrt-Windows.Media.Capture>=2.2.0 ; sys_platform == 'win32'  # Python 3.13 support
 # D3DShot # See install.ps1
 #
 # Linux-only dependencies

--- a/src/capture_method/WindowsGraphicsCaptureMethod.py
+++ b/src/capture_method/WindowsGraphicsCaptureMethod.py
@@ -9,12 +9,12 @@ import numpy as np
 import win32gui
 from cv2.typing import MatLike
 from typing_extensions import override
-from winsdk.windows.graphics import SizeInt32
-from winsdk.windows.graphics.capture import Direct3D11CaptureFramePool, GraphicsCaptureSession
-from winsdk.windows.graphics.capture.interop import create_for_window
-from winsdk.windows.graphics.directx import DirectXPixelFormat
-from winsdk.windows.graphics.directx.direct3d11 import IDirect3DSurface
-from winsdk.windows.graphics.imaging import BitmapBufferAccessMode, SoftwareBitmap
+from winrt.windows.graphics import SizeInt32
+from winrt.windows.graphics.capture import Direct3D11CaptureFramePool, GraphicsCaptureSession
+from winrt.windows.graphics.capture.interop import create_for_window
+from winrt.windows.graphics.directx import DirectXPixelFormat
+from winrt.windows.graphics.directx.direct3d11 import IDirect3DSurface
+from winrt.windows.graphics.imaging import BitmapBufferAccessMode, SoftwareBitmap
 
 from capture_method.CaptureMethodBase import CaptureMethodBase
 from utils import (

--- a/src/region_selection.py
+++ b/src/region_selection.py
@@ -32,9 +32,9 @@ if sys.platform == "win32":
         SM_XVIRTUALSCREEN,
         SM_YVIRTUALSCREEN,
     )
-    from winsdk._winrt import initialize_with_window  # noqa: PLC2701
-    from winsdk.windows.foundation import AsyncStatus, IAsyncOperation
-    from winsdk.windows.graphics.capture import GraphicsCaptureItem, GraphicsCapturePicker
+    from winrt._winrt import initialize_with_window  # noqa: PLC2701
+    from winrt.windows.foundation import AsyncStatus, IAsyncOperation
+    from winrt.windows.graphics.capture import GraphicsCaptureItem, GraphicsCapturePicker
 
 if sys.platform == "linux":
     from Xlib.display import Display

--- a/src/user_profile.py
+++ b/src/user_profile.py
@@ -114,8 +114,7 @@ def save_settings_as(autosplit: "AutoSplit"):
 def __save_settings_to_file(autosplit: "AutoSplit", save_settings_file_path: str):
     # Save settings to a .toml file
     with open(save_settings_file_path, "wb") as file:
-        # https://github.com/hukkin/tomli-w/pull/46
-        tomli_w.dump(autosplit.settings_dict, file)  # pyright: ignore[reportArgumentType]
+        tomli_w.dump(autosplit.settings_dict, file)
     autosplit.last_saved_settings = deepcopy(autosplit.settings_dict)
     autosplit.last_successfully_loaded_settings_file_path = save_settings_file_path
     return save_settings_file_path

--- a/src/utils.py
+++ b/src/utils.py
@@ -25,8 +25,8 @@ if sys.platform == "win32":
     import win32gui
     import win32ui
     from pygrabber.dshow_graph import FilterGraph
-    from winsdk.windows.ai.machinelearning import LearningModelDevice, LearningModelDeviceKind
-    from winsdk.windows.media.capture import MediaCapture
+    from winrt.windows.ai.machinelearning import LearningModelDevice, LearningModelDeviceKind
+    from winrt.windows.media.capture import MediaCapture
 
     STARTUPINFO: TypeAlias = subprocess.STARTUPINFO
 else:


### PR DESCRIPTION
Cleanly getting an `IDirect3DDevice` is still a mystery though https://github.com/pywinrt/pywinrt/issues/78

Looking at the artefact, it looks like this reduced the build size by 10MB or ~7% Nice