### PR TITLE
Used UPX to reduce Windows x64 build size by ~23MB (~23%)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+.upx/
 
 # Dev settings
 settings.toml

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -2,19 +2,21 @@
 
 & "$PSScriptRoot/compile_resources.ps1"
 
+$ProjectRoot = "$PSScriptRoot/.."
 $SupportsSplashScreen = [System.Convert]::ToBoolean($(uv run --active python -c "import _tkinter; print(hasattr(_tkinter, '__file__'))"))
 
 $arguments = @(
-  "$PSScriptRoot/../src/AutoSplit.py",
+  "$ProjectRoot/src/AutoSplit.py",
   '--onefile',
   '--windowed',
-  '--additional-hooks-dir=Pyinstaller/hooks',
   '--optimize 2', # Remove asserts and docstrings for smaller build
-  "--add-data=pyproject.toml$([System.IO.Path]::PathSeparator).",
-  '--icon=res/icon.ico')
+  "--additional-hooks-dir=$ProjectRoot/Pyinstaller/hooks",
+  "--add-data=$ProjectRoot/pyproject.toml$([System.IO.Path]::PathSeparator).",
+  "--upx-dir=$PSScriptRoot/.upx"
+  "--icon=$ProjectRoot/res/icon.ico")
 if ($SupportsSplashScreen) {
   # https://github.com/pyinstaller/pyinstaller/issues/9022
-  $arguments += @('--splash=res/splash.png')
+  $arguments += @("--splash=$ProjectRoot/res/splash.png")
 }
 if ($IsWindows) {
   $arguments += @(
@@ -25,10 +27,10 @@ if ($IsWindows) {
 Start-Process -Wait -NoNewWindow uv -ArgumentList $(@('run', '--active', 'pyinstaller') + $arguments)
 
 If ($IsLinux) {
-  Move-Item -Force $PSScriptRoot/../dist/AutoSplit $PSScriptRoot/../dist/AutoSplit.elf
+  Move-Item -Force $ProjectRoot/dist/AutoSplit $ProjectRoot/dist/AutoSplit.elf
   If ($?) {
     Write-Host 'Added .elf extension'
   }
-  chmod +x $PSScriptRoot/../dist/AutoSplit.elf
+  chmod +x $ProjectRoot/dist/AutoSplit.elf
   Write-Host 'Added execute permission'
 }


### PR DESCRIPTION
Also improved some scripts relative paths whilst I was here.

UPX is only used by PyInstaller on Windows: https://pyinstaller.org/en/stable/usage.html#using-upx

UPX doesn't really support ARM64: https://github.com/upx/upx/issues?q=is%3Aissue%20is%3Aopen%20arm64
- Specifically https://github.com/upx/upx/issues/650